### PR TITLE
added cli for dcm2niix for PET

### DIFF
--- a/.github/workflows/setup_and_cli_test_posix.yaml
+++ b/.github/workflows/setup_and_cli_test_posix.yaml
@@ -58,12 +58,12 @@ jobs:
       - name: Test CLI --help
         run: |
           cd pypet2bids/
-          python3 -m pypet2bids.cli --help
+          python3 -m pypet2bids.ecat_cli --help
 
       - name: Test CLI Ecat Dump
         run: |
           cd pypet2bids/
-          python3 -m pypet2bids.cli ../${{ env.REAL_TEST_ECAT_PATH }} --dump
+          python3 -m pypet2bids.ecat_cli ../${{ env.REAL_TEST_ECAT_PATH }} --dump
 
       # the larger real data file uses too much ram for the github runner, we use the small file for
       # heavy io operations instead

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 build/
 dist/
 *.spec
+pypet2bids/pypet2bids/metadata
 
 # Inherited cookiecutter files
 HISTORY.rst
@@ -41,3 +42,4 @@ test_env/
 # sphinx
 docs/_build/*/*.pickle
 docs/_build/
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+# add a dependency, this is an alias for poetry add that also updates the requirements.txt file
+add:
+	@scripts/add_python_dependency $(ARGUMENTS)
+
+# copies metadata to path included in pypet2bids project to enable packaging of those files w/ poetry
+build:
+	@cp -R metadata/ pypet2bids/pypet2bids/metadata
+	@cd pypet2bids && poetry build
+

--- a/pypet2bids/pypet2bids/dcm2niix4pet.py
+++ b/pypet2bids/pypet2bids/dcm2niix4pet.py
@@ -1,4 +1,5 @@
 from json_maj.main import JsonMAJ, load_json_or_dict
+from pypet2bids.helper_functions import ParseKwargs
 import importlib.util
 import subprocess
 import pandas as pd
@@ -15,6 +16,7 @@ from tempfile import TemporaryDirectory
 import shutil
 from dateutil import parser
 from termcolor import colored
+import argparse
 
 
 """
@@ -31,9 +33,13 @@ python_folder = module_folder.parent
 pet2bids_folder = python_folder.parent
 metadata_folder = join(pet2bids_folder, 'metadata')
 
-# collect metadata jsons
-metadata_jsons = \
-    [Path(join(metadata_folder, metadata_json)) for metadata_json in listdir(metadata_folder) if '.json' in metadata_json]
+try:
+    # collect metadata jsons in dev mode
+    metadata_jsons = \
+        [Path(join(metadata_folder, metadata_json)) for metadata_json in listdir(metadata_folder) if '.json' in metadata_json]
+except FileNotFoundError:
+    metadata_jsons = \
+        [Path(join(module_folder, 'metadata', metadata_json)) for metadata_json in listdir(join(module_folder, 'metadata')) if '.json' in metadata_json]
 
 # create a dictionary to house the PET metadata files
 metadata_dictionaries = {}
@@ -68,7 +74,7 @@ def check_json(path_to_json, items_to_check=None, silent=False):
 
     # check for default argument for dictionary of items to check
     if items_to_check is None:
-        items_to_check = metada_dictionaries['PET_metadata.json']
+        items_to_check = metadata_dictionaries['PET_metadata.json']
 
     # open the json
     with open(path_to_json, 'r') as infile:
@@ -429,5 +435,60 @@ class Dcm2niix4PET:
                         headers_to_files[each] = [output_file]
         return headers_to_files
 
-if __name__ == "__main__":
-    pass
+def cli():
+    """
+    Collects arguments used to initiate a Dcm2niix4PET class, collects the following arguments from the user.
+
+    :param folder: folder containing imaging data, no flag required
+    :param -m, --metadata-path: path to PET metadata spreadsheet
+    :param -t, --translation-script-path: path to script used to extract information from metadata spreadsheet
+    :param -d, --destination-path: path to place outputfiles post conversion from dicom to nifti + json
+    :return: arguments collected from argument parser
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument('folder', type=str,
+                        help="Folder path containing imaging data")
+    parser.add_argument('--metadata-path', '-m', type=str, default=None,
+                        help="Path to metadata file for scan")
+    parser.add_argument('--translation-script-path', '-t', default=None,
+                        help="Path to a script written to extract and transform metadata from a spreadsheet to BIDS" +
+                             " compliant text files (tsv and json)")
+    parser.add_argument('--destination-path', '-d', type=str, default=None,
+                        help="Destination path to send converted imaging and metadata files to. If " +
+                             "omitted defaults to using the path supplied to folder path. If destination path " +
+                             "doesn't exist an attempt to create it will be made.", required=False)
+    parser.add_argument('--kwargs', '-k', nargs='*', action=ParseKwargs, default={},
+                        help="Include additional values int the nifti sidecar json or override values extracted from "
+                             "the supplied nifti. e.g. including `--kwargs TimeZero='12:12:12'` would override the "
+                             "calculated TimeZero. Any number of additional arguments can be supplied after --kwargs "
+                             "e.g. `--kwargs BidsVariable1=1 BidsVariable2=2` etc etc.")
+    parser.add_argument('--silent', '-s', type=bool, default=False, help="Display missing metadata warnings and errors"
+                                                                         "to stdout/stderr")
+
+    args = parser.parse_args()
+
+    return args
+
+def main():
+    """
+    Executes cli() and uses Dcm2niix4PET class to convert a folder containing dicoms into nifti + json.
+
+    :return: None
+    """
+
+    # collect args
+    cli_args = cli()
+
+    # instantiate class
+    converter = Dcm2niix4PET(
+        image_folder=cli_args.folder,
+        destination_path=cli_args.destination_path,
+        metadata_path=cli_args.metadata_path,
+        metadata_translation_script=cli_args.translation_script_path,
+        additional_arguments=cli_args.kwargs,
+        silent=cli_args.silent)
+
+    converter.run_dcm2niix()
+
+if __name__ == '__main__':
+    main()

--- a/pypet2bids/pypet2bids/ecat_cli.py
+++ b/pypet2bids/pypet2bids/ecat_cli.py
@@ -4,26 +4,11 @@ import pathlib
 import sys
 from os.path import join
 from pypet2bids.ecat import Ecat
-from pypet2bids.helper_functions import load_vars_from_config
+from pypet2bids.helper_functions import load_vars_from_config, ParseKwargs
 
 """
 simple command line tool to extract header and pixel information from ecat files and convert ecat to nifti.
 """
-
-
-class ParseKwargs(argparse.Action):
-    """
-    Class that is used to extract key pair arguments passed to an argparse.ArgumentParser objet via the command line.
-    Accepts key value pairs in the form of 'key=value' and then passes these arguments onto the arg parser as kwargs.
-    This class is used during the construction of the ArgumentParser class via the add_argument method. e.g.:\n
-    `ArgumentParser.add_argument('--kwargs', '-k', nargs='*', action=ParseKwargs, default={})`
-    """
-    def __call__(self, parser, namespace, values, option_string=None):
-        setattr(namespace, self.dest, dict())
-        for value in values:
-            key, value = value.split('=')
-            getattr(namespace, self.dest)[key] = value
-
 
 def cli():
     """

--- a/pypet2bids/pypet2bids/helper_functions.py
+++ b/pypet2bids/pypet2bids/helper_functions.py
@@ -3,6 +3,7 @@ import os
 import re
 import dotenv
 import ast
+import argparse
 
 
 def compress(file_like_object, output_path: str = None):
@@ -71,3 +72,16 @@ def load_vars_from_config(path_to_config: str):
             parameters[parameter] = str(value)
 
     return parameters
+
+class ParseKwargs(argparse.Action):
+    """
+    Class that is used to extract key pair arguments passed to an argparse.ArgumentParser objet via the command line.
+    Accepts key value pairs in the form of 'key=value' and then passes these arguments onto the arg parser as kwargs.
+    This class is used during the construction of the ArgumentParser class via the add_argument method. e.g.:\n
+    `ArgumentParser.add_argument('--kwargs', '-k', nargs='*', action=ParseKwargs, default={})`
+    """
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, dict())
+        for value in values:
+            key, value = value.split('=')
+            getattr(namespace, self.dest)[key] = value

--- a/pypet2bids/pyproject.toml
+++ b/pypet2bids/pyproject.toml
@@ -4,6 +4,13 @@ version = "0.0.6"
 description = "A python implementation of an ECAT to BIDS converter."
 authors = ["anthony galassi <28850131+bendhouseart@users.noreply.github.com>"]
 license = "MIT"
+include = [
+    'pypet2bids/metadata/blood_metadata.json',
+    'pypet2bids/metadata/definitions.json',
+    'pypet2bids/metadata/dicom2bids.json',
+    'pypet2bids/metadata/PET_metadata.json',
+    'pypet2bids/metadata/PET_Radionuclide.mkd',
+    ]
 
 [tool.poetry.dependencies]
 python = ">3.7.1,<3.10"
@@ -26,8 +33,9 @@ sphinxcontrib-matlabdomain = "^0.13.0"
 [tool.poetry.dev-dependencies]
 
 [tool.poetry.scripts]
-pypet2bids = 'pypet2bids.cli:main'
+ecatpet2bids = 'pypet2bids.ecat_cli:main'
 dcm2petbids = 'pypet2bids.dicom_convert:cli'
+dcm2niix4pet = 'pypet2bids.dcm2niix4pet:main'
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
Added poetry 'build' command to Makefile to copy over metadata folder files to
a path that poetry/python packaging could resolve. Updated .gitignore to suit.

Renamed cli.py to ecat_cli.py since there is more than one cli floating around.

Added metadata copied from metadata/ folder project.toml for packaging

Moved key=value argparser object to helperfunctions as it's going to be used
everywhere in this project to accept user input metadata for PET.