### PR TITLE
Added dicom recon method inputs and BIDS outputs

### DIFF
--- a/metadata/PET_dicom_reconstruction_methods.json
+++ b/metadata/PET_dicom_reconstruction_methods.json
@@ -1,0 +1,130 @@
+{
+  "reconstruction_method_strings": [
+    {
+      "contents": "PSF+TOF 3i21s",
+      "subsets": 21,
+      "iterations": 3,
+      "ReconMethodName": "PSF+TOF",
+      "ReconMethodParameterUnits": [
+        null,
+        null
+      ],
+      "ReconMethodParameterLabels": [
+        "subsets",
+        "iterations"
+      ],
+      "ReconMethodParameterValues": [
+        21,
+        3
+      ]
+    },
+    {
+      "contents": "OP-OSEM3i21s",
+      "subsets": 21,
+      "iterations": 3,
+      "ReconMethodName": "OP-OSEM",
+      "ReconMethodParameterUnits": [
+        null,
+        null
+      ],
+      "ReconMethodParameterLabels": [
+        "subsets",
+        "iterations"
+      ],
+      "ReconMethodParameterValues": [
+        21,
+        3
+      ]
+    },
+    {
+      "contents": "PSF+TOF 3i21s",
+      "subsets": 21,
+      "iterations": 3,
+      "ReconMethodName": "PSF+TOF",
+      "ReconMethodParameterUnits": [
+        null,
+        null
+      ],
+      "ReconMethodParameterLabels": [
+        "subsets",
+        "iterations"
+      ],
+      "ReconMethodParameterValues": [
+        21,
+        3
+      ]
+    },
+    {
+      "contents": "LOR-RAMLA",
+      "subsets": null,
+      "iterations": null,
+      "ReconMethodName": "LOR-RAMLA",
+      "ReconMethodParameterUnits": [
+        "none",
+        "none"
+      ],
+      "ReconMethodParameterLabels": [
+        "subsets",
+        "iterations"
+      ],
+      "ReconMethodParameterValues": [
+        null,
+        null
+      ]
+    },
+    {
+      "contents": "3D-RAMLA",
+      "subsets": null,
+      "iterations": null,
+      "ReconMethodName": "3D-RAMLA",
+      "ReconMethodParameterUnits": [
+        null,
+        null
+      ],
+      "ReconMethodParameterLabels": [
+        "subsets",
+        "iterations"
+      ],
+      "ReconMethodParameterValues": [
+        "",
+        ""
+      ]
+    },
+    {
+      "contents": "OSEM:i3s15",
+      "subsets": 15,
+      "iterations": 3,
+      "ReconMethodName": "OSEM",
+      "ReconMethodParameterUnits": [
+        null,
+        null
+      ],
+      "ReconMethodParameterLabels": [
+        "subsets",
+        "iterations"
+      ],
+      "ReconMethodParameterValues": [
+        15,
+        3
+      ]
+    },
+    {
+      "contents": "LOR-RAMLA",
+      "subsets": null,
+      "iterations": null,
+      "ReconMethodName": "LOR-RAMLA",
+      "ReconMethodParameterUnits": [
+        null,
+        null
+      ],
+      "ReconMethodParameterLabels": [
+        "subsets",
+        "iterations"
+      ],
+      "ReconMethodParameterValues": [
+        null,
+        null
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adding in a json file in metadata containing given ReconstructionMethod
input, along with the desired BIDS outputs that would result upon
collecting said input from a dicom file. This file will be used
in Matlab and Python for CI and testing.