### PR TITLE
Added write out TracerRadionuclide from dicom to json

### DIFF
--- a/pypet2bids/pypet2bids/dcm2niix4pet.py
+++ b/pypet2bids/pypet2bids/dcm2niix4pet.py
@@ -221,7 +221,6 @@ def update_json_with_dicom_value(
     Radionuclide = get_radionuclide(dicom_header)
     if Radionuclide:
         json_updater.update({'TracerRadionuclide': Radionuclide})
-    print("PAUSE")
 
 
 def dicom_datetime_to_dcm2niix_time(dicom=None, date='', time=''):

--- a/pypet2bids/pyproject.toml
+++ b/pypet2bids/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pypet2bids"
-version = "0.0.11"
+version = "0.0.12"
 description = "A python implementation of an ECAT to BIDS converter."
 authors = ["anthony galassi <28850131+bendhouseart@users.noreply.github.com>"]
 license = "MIT"


### PR DESCRIPTION
added method to get TracerRadionuclide from dicom header and then
if gotten to write it out to the nifti sidecar.json

Can still be overridden w/ command line argument or by placing value
in spreadsheet.