### PR TITLE
Sanitize bad paths

### DIFF
--- a/pypet2bids/pypet2bids/dcm2niix4pet.py
+++ b/pypet2bids/pypet2bids/dcm2niix4pet.py
@@ -19,6 +19,7 @@ import warnings
 from json_maj.main import JsonMAJ, load_json_or_dict
 from pypet2bids.helper_functions import ParseKwargs, get_version, translate_metadata, expand_path, collect_bids_part
 from pypet2bids.helper_functions import get_recon_method, is_numeric, single_spreadsheet_reader, set_dcm2niix_path
+from pypet2bids.helper_functions import sanitize_bad_path
 from platform import system
 import subprocess
 import pandas as pd
@@ -497,7 +498,9 @@ class Dcm2niix4PET:
             file_format_args = ""
         with TemporaryDirectory() as tempdir:
             tempdir_pathlike = Path(tempdir)
-            cmd = f"{self.dcm2niix_path} -w 1 -z y {file_format_args} -o {tempdir_pathlike} {self.image_folder}"
+            # people use screwy paths, we do this before running dcm2niix to account for that
+            image_folder = sanitize_bad_path(self.image_folder)
+            cmd = f"{self.dcm2niix_path} -w 1 -z y {file_format_args} -o {tempdir_pathlike} {image_folder}"
             convert = subprocess.run(cmd, shell=True, capture_output=True)
 
             if convert.returncode != 0:

--- a/pypet2bids/pypet2bids/helper_functions.py
+++ b/pypet2bids/pypet2bids/helper_functions.py
@@ -638,3 +638,10 @@ def set_dcm2niix_path(dc2niix_path: pathlib.Path):
         # create the file
         with open(config_file, 'w') as outfile:
             outfile.write(f'DCM2NIIX_PATH={dc2niix_path}\n')
+
+
+def sanitize_bad_path(bad_path: Union[str, pathlib.Path]) -> str:
+    if ' ' in str(bad_path):
+        return f"'{bad_path}'"
+    else:
+        return bad_path

--- a/pypet2bids/pypet2bids/helper_functions.py
+++ b/pypet2bids/pypet2bids/helper_functions.py
@@ -642,6 +642,6 @@ def set_dcm2niix_path(dc2niix_path: pathlib.Path):
 
 def sanitize_bad_path(bad_path: Union[str, pathlib.Path]) -> Union[str, pathlib.Path]:
     if ' ' in str(bad_path):
-        return f"'{bad_path}'"
+        return f'"{bad_path}"'.rstrip().strip()
     else:
         return bad_path

--- a/pypet2bids/pypet2bids/helper_functions.py
+++ b/pypet2bids/pypet2bids/helper_functions.py
@@ -640,7 +640,7 @@ def set_dcm2niix_path(dc2niix_path: pathlib.Path):
             outfile.write(f'DCM2NIIX_PATH={dc2niix_path}\n')
 
 
-def sanitize_bad_path(bad_path: Union[str, pathlib.Path]) -> str:
+def sanitize_bad_path(bad_path: Union[str, pathlib.Path]) -> Union[str, pathlib.Path]:
     if ' ' in str(bad_path):
         return f"'{bad_path}'"
     else:

--- a/pypet2bids/pyproject.toml
+++ b/pypet2bids/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pypet2bids"
-version = "1.0.5"
+version = "1.0.6"
 description = "A python implementation of an ECAT to BIDS converter."
 authors = ["anthony galassi <28850131+bendhouseart@users.noreply.github.com>"]
 license = "MIT"


### PR DESCRIPTION
Windows is bad, spaces are bad, this might need to escape/handle more than just that sort of nonsense. Currently just wraps quotes around paths passed to dcm2niix *if* they contain spaces. 

Need to test further on wacky windows paths.