### PR TITLE
Use full filename if given

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Decompress dataset
         if: steps.cache-ecat.outputs.cache-hit != 'true'
-        run: "tar xvzf ecat_test && rm ecat_test"
+        run: "unzip ecat_test && rm ecat_test"
 
       - name: Test CLI --help
         run: |

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Decompress dataset
         if: steps.cache-ecat.outputs.cache-hit != 'true'
-        run: "unzip ecat_test && rm ecat_test"
+        run: "tar xvzf ecat_test && rm ecat_test"
 
       - name: Test CLI --help
         run: |

--- a/pypet2bids/pypet2bids/dcm2niix4pet.py
+++ b/pypet2bids/pypet2bids/dcm2niix4pet.py
@@ -379,9 +379,18 @@ class Dcm2niix4PET:
         # are doing in that case
         self.full_file_path_given = False
         for part in self.destination_path.parts:
-            if '.nii' or '.nii.gz' in part:
+            if '.nii' in part or '.nii.gz' in part:
                 self.full_file_path_given = True
+                # replace .nii and .nii.gz
+                self.destination_path = Path(str(self.destination_path).replace('.nii', '').replace('.gz', ''))
+                break
 
+        # replace the suffix in the destination path with '' if a non-nifti full file path is give
+        if Path(self.destination_path).suffix:
+            self.full_file_path_given = True
+            self.destination_path = Path(self.destination_path).with_suffix('')
+
+        # extract PET filename parts from destination path if given
         self.subject_id = helper_functions.collect_bids_part('sub', str(self.destination_path))
         self.session_id = helper_functions.collect_bids_part('ses', str(self.destination_path))
         self.task = helper_functions.collect_bids_part('task', str(self.destination_path))
@@ -547,12 +556,15 @@ class Dcm2niix4PET:
             files_created_by_dcm2niix = [join(tempdir_pathlike, file) for file in listdir(tempdir_pathlike)]
 
             # make sure destination path exists if not try creating it.
-            if self.destination_path.exists():
+            try:
+                if self.destination_path.exists():
+                    pass
+                elif not self.destination_path.exists() and self.full_file_path_given:
+                    self.destination_path.parent.mkdir(parents=True, exist_ok=True)
+                else:
+                    self.destination_path.mkdir(parents=True, exist_ok=True)
+            except FileExistsError:
                 pass
-            elif not self.destination_path.exists() and self.full_file_path_given:
-                self.destination_path.parent.mkdir(parents=True, exist_ok=True)
-            else:
-                self.destination_path.mkdir(parents=True, exist_ok=True)
 
             # iterate through created files to supplement sidecar jsons
             for created in files_created_by_dcm2niix:
@@ -684,20 +696,38 @@ class Dcm2niix4PET:
 
                     if self.task:
                         task = '_' + self.task
+                    else:
+                        task = ''
 
                     if self.tracer:
                         trc = '_' + self.tracer
+                    else:
+                        trc = ''
 
                     if self.reconstruction_method:
                         rec = '_' + self.reconstruction_method
+                    else:
+                        rec = ''
 
                     if self.run_id:
                         run = '_' + self.run_id
+                    else:
+                        run = ''
 
-                    new_path = Path(join(self.destination_path),
-                                    self.subject_id + session_id + task + trc + rec + run + '_pet' + suffix)
-                else:
+                    if self.full_file_path_given:
+                        new_path = self.destination_path.with_suffix(suffix)
+                    else:
+                        new_path = self.destination_path / Path(self.subject_id + session_id + task + trc + rec +
+                                                                     run + '_pet' + suffix)
+
+                    try:
+                        new_path.parent.mkdir(parents=True, exist_ok=True)
+                    except FileExistsError:
+                        pass
+
+                elif not self.subject_id:
                     new_path = Path(join(self.destination_path, created_path.name))
+
                 shutil.move(src=created, dst=new_path)
 
             return self.destination_path

--- a/pypet2bids/pypet2bids/helper_functions.py
+++ b/pypet2bids/pypet2bids/helper_functions.py
@@ -458,6 +458,16 @@ def collect_bids_part(bids_part: str, path_like: Union[str, pathlib.Path]) -> st
         else:
             collected_part = ''
 
+    if '_' in collected_part:
+        parts = collected_part.split('_')
+        for part in parts:
+            found_part = re.search(search_string, part)
+            if found_part:
+                collected_part = found_part[0]
+                break
+            else:
+                collected_part = ''
+
     return collected_part
 
 

--- a/pypet2bids/tests/test_helper_functions.py
+++ b/pypet2bids/tests/test_helper_functions.py
@@ -119,6 +119,14 @@ def test_collect_bids_parts():
     nope_ses = helper_functions.collect_bids_part('ses', not_bids_like_path)
     assert nope_ses == ''
 
+    pet_path = '/home/users/user/bids_data/sub-NDAR123_ses-01_task-countbackwards_trc-CBGB_rec-ACDYN_run-03'
+    assert helper_functions.collect_bids_part('sub', pet_path) == 'sub-NDAR123'
+    assert helper_functions.collect_bids_part('ses', pet_path) == 'ses-01'
+    assert helper_functions.collect_bids_part('task', pet_path) == 'task-countbackwards'
+    assert helper_functions.collect_bids_part('trc', pet_path) == 'trc-CBGB'
+    assert helper_functions.collect_bids_part('rec', pet_path) == 'rec-ACDYN'
+    assert helper_functions.collect_bids_part('run', pet_path) == 'run-03'
+
 
 def test_transform_row_to_dict():
     # load real test data from many subject sheet

--- a/scripts/testphantoms
+++ b/scripts/testphantoms
@@ -18,8 +18,16 @@ make installpackage
 
 # Collect Phantoms
 GDRIVE_PHANTOM_ID=$(grep GDRIVE_PHANTOM_ID pypet2bids/.env)
+PHANTOM_ZIP_FILE=PHANTOMS.ZIP
 export $GDRIVE_PHANTOM_ID
-gdown $GDRIVE_PHANTOM_ID -O PHANTOMS.zip
+if [ -f $PHANTOM_ZIP_FILE ]; then
+  echo "$PHANTOM_ZIP_FILE exists, skipping download..."
+else
+  gdown $GDRIVE_PHANTOM_ID -O PHANTOMS.zip
+fi
+
+# cleanup old run of conversions
+rm -rf OpenNeuroPET-Phantoms
 
 # Unzip Phantoms
 unzip -oq PHANTOMS.zip


### PR DESCRIPTION
Updated dcm2niix4pet to parse BIDS entities from a nifti (or any) file is given as the destination argument.

`dcm2niix4pet sourcefolder -d /sub-01/ses-01/sub-01_ses-01_task-testtask_trc-C15_pet.nii.gz` will search the entire destination string, not just the parent folders for subject and session.

The output of the above command will be:

```
/sub-01/ses-01/sub-01_ses-01_task-testtask_trc-C15_pet.nii.gz
/sub-01/ses-01/sub-01_ses-01_task-testtask_trc-C15_pet.json
```