### PR TITLE
Locate PET Spreadsheet in Imaging or Specified Folder

### DIFF
--- a/pypet2bids/pypet2bids/helper_functions.py
+++ b/pypet2bids/pypet2bids/helper_functions.py
@@ -77,6 +77,15 @@ def flatten_series(series):
     return simplified_series_object
 
 
+def collect_spreadsheets(folder_path: pathlib.Path):
+    spreadsheet_files = []
+    all_files = [folder_path / pathlib.Path(file) for file in os.listdir(folder_path) if os.path.isfile(os.path.join(folder_path, file))]
+    for file in all_files:
+        if file.suffix == '.xlsx' or file.suffix == '.csv' or file.suffix == '.xls' or file.suffix == '.tsv':
+            spreadsheet_files.append(file)
+    return spreadsheet_files
+
+
 def single_spreadsheet_reader(
         path_to_spreadsheet: Union[str, pathlib.Path],
         pet2bids_metadata_json: Union[str, pathlib.Path] = pet_metadata_json,

--- a/pypet2bids/pypet2bids/single_spreadsheet.py
+++ b/pypet2bids/pypet2bids/single_spreadsheet.py
@@ -13,7 +13,6 @@ except ModuleNotFoundError:
 #from pypet2bids.helper_functions import single_spreadsheet_reader, \
 #    collect_bids_part, open_meta_data, load_pet_bids_requirements_json, ParseKwargs
 
-
 def read_single_subject_spreadsheets(
         general_metadata_spreadsheet: pathlib.Path,
         **kwargs) -> dict:

--- a/pypet2bids/pyproject.toml
+++ b/pypet2bids/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pypet2bids"
-version = "1.1.2"
+version = "1.2.2"
 description = "A python implementation of an ECAT to BIDS converter."
 authors = ["anthony galassi <28850131+bendhouseart@users.noreply.github.com>"]
 license = "MIT"

--- a/pypet2bids/tests/test_helper_functions.py
+++ b/pypet2bids/tests/test_helper_functions.py
@@ -4,6 +4,7 @@ import unittest
 import datetime
 try:
     import pypet2bids.helper_functions as helper_functions
+    import pypet2bids.is_pet as is_pet
 except ModuleNotFoundError:
     raise ModuleNotFoundError
 
@@ -299,6 +300,11 @@ def test_read_multi_sheet():
     assert(multi_spreadsheet['TimeZero'][0] == datetime.time(12,12,12))
     assert(multi_spreadsheet['TracerName'][0] == 'OverrideTracerNameIn0thSheet')
 
+
+def test_collect_pet_spreadsheets():
+    pet_spreadsheet_dir = Path(single_subject_metadata_file).parent
+    pet_spreadsheets = helper_functions.collect_spreadsheets(pet_spreadsheet_dir)
+    assert(len(pet_spreadsheets) == 3)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR adds functionality such that:

- If dcm2niix4pet is given the flag `--metadata-path` with no arguments it will search the image folder argument for a pet metadata spreadsheet and apply it
- If dcm2niix4pet is given the flag `--metadat-path` with a folder argument instead of "" or a file path, it will search the specified folder.