### PR TITLE
[ENH] Convert Boolean like Values to Python Type Bools

### DIFF
--- a/metadata/schema.json
+++ b/metadata/schema.json
@@ -1,0 +1,12608 @@
+{
+  "schema_version": "0.6.0",
+  "bids_version": "1.8.0",
+  "meta": {
+    "context": {
+      "context": {
+        "type": "object",
+        "properties": {
+          "schema": {
+            "description": "The BIDS specification schema",
+            "type": "object"
+          },
+          "dataset": {
+            "description": "Properties and contents of the entire dataset",
+            "type": "object",
+            "properties": {
+              "dataset_description": {
+                "description": "Contents of /dataset_description.json",
+                "type": "object"
+              },
+              "files": {
+                "description": "List of all files in dataset",
+                "type": "array"
+              },
+              "tree": {
+                "description": "Tree view of all files in dataset",
+                "type": "object"
+              },
+              "ignored": {
+                "description": "Set of ignored files",
+                "type": "array"
+              },
+              "datatypes": {
+                "description": "Data types present in the dataset",
+                "type": "array"
+              },
+              "modalities": {
+                "description": "Modalities present in the dataset",
+                "type": "array"
+              },
+              "subjects": {
+                "description": "Collections of subjects in dataset",
+                "type": "object",
+                "properties": {
+                  "sub_dirs": {
+                    "description": "Subjects as determined by sub-*/ directories",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "participant_id": {
+                    "description": "The participant_id column of participants.tsv",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "phenotype": {
+                    "description": "The union of participant_id columns in phenotype files",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "subject": {
+            "description": "Properties and contents of the current subject",
+            "type": "object",
+            "properties": {
+              "sessions": {
+                "description": "Collections of sessions in subject",
+                "type": "object",
+                "properties": {
+                  "ses_dirs": {
+                    "description": "Sessions as determined by ses-*/ directories",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "session_id": {
+                    "description": "The session_id column of sessions.tsv",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "phenotype": {
+                    "description": "The union of session_id columns in phenotype files",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "path": {
+            "description": "Path of the current file",
+            "type": "string"
+          },
+          "entities": {
+            "description": "Entities parsed from the current filename",
+            "type": "object"
+          },
+          "datatype": {
+            "description": "Datatype of current file, for examples, anat",
+            "type": "string"
+          },
+          "suffix": {
+            "description": "Suffix of current file",
+            "type": "string"
+          },
+          "extension": {
+            "description": "Extension of current file including initial dot",
+            "type": "string"
+          },
+          "modality": {
+            "description": "Modality of current file, for examples, MRI",
+            "type": "string"
+          },
+          "sidecar": {
+            "description": "Sidecar metadata constructed via the inheritance principle",
+            "type": "object"
+          },
+          "associations": {
+            "description": "Associated files, indexed by suffix, selected according to the inheritance principle\n",
+            "type": "object",
+            "properties": {
+              "events": {
+                "description": "Events file",
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "description": "Path to associated events file",
+                    "type": "string"
+                  },
+                  "onset": {
+                    "description": "Contents of the onset column",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "aslcontext": {
+                "description": "ASL context file",
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "description": "Path to associated aslcontext file",
+                    "type": "string"
+                  },
+                  "n_rows": {
+                    "description": "Number of rows in aslcontext.tsv",
+                    "type": "integer"
+                  },
+                  "volume_type": {
+                    "description": "Contents of the volume_type column",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "m0scan": {
+                "description": "M0 scan file",
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "description": "Path to associated M0 scan file",
+                    "type": "string"
+                  }
+                }
+              },
+              "magnitude": {
+                "description": "Magnitude image file",
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "description": "Path to associated magnitude file",
+                    "type": "string"
+                  }
+                }
+              },
+              "magnitude1": {
+                "description": "Magnitude1 image file",
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "description": "Path to associated magnitude1 file",
+                    "type": "string"
+                  }
+                }
+              },
+              "bval": {
+                "description": "B value file",
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "description": "Path to associated bval file",
+                    "type": "string"
+                  },
+                  "n_cols": {
+                    "description": "Number of columns in bval file",
+                    "type": "integer"
+                  }
+                }
+              },
+              "bvec": {
+                "description": "B vector file",
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "description": "Path to associated bvec file",
+                    "type": "string"
+                  },
+                  "n_cols": {
+                    "description": "Number of columns in bvec file",
+                    "type": "integer"
+                  }
+                }
+              },
+              "channels": {
+                "description": "Channels file",
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "description": "Path to associated channels file",
+                    "type": "string"
+                  },
+                  "type": {
+                    "description": "Contents of the type column",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "coordsystem": {
+                "description": "Coordinate system file",
+                "type": "object",
+                "properties": {
+                  "path": {
+                    "description": "Path to associated coordsystem file",
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "columns": {
+            "description": "TSV columns, indexed by column header, values are arrays with column contents",
+            "type": "object",
+            "additionalProperties": {
+              "type": "array"
+            }
+          },
+          "json": {
+            "description": "Contents of the current JSON file",
+            "type": "object"
+          },
+          "nifti_header": {
+            "name": "NIfTI Header",
+            "description": "Parsed contents of NIfTI header referenced elsewhere in schema.",
+            "type": "object",
+            "properties": {
+              "dim_info": {
+                "name": "Dimension Information",
+                "description": "Metadata about dimensions data.",
+                "type": "object",
+                "properties": {
+                  "freq": {
+                    "name": "Frequency",
+                    "description": "These fields encode which spatial dimension (1, 2, or 3).",
+                    "type": "integer"
+                  },
+                  "phase": {
+                    "name": "Phase",
+                    "description": "Corresponds to which acquisition dimension for MRI data.",
+                    "type": "integer"
+                  },
+                  "slice": {
+                    "name": "Slice",
+                    "description": "Slice dimensions.",
+                    "type": "integer"
+                  }
+                }
+              },
+              "dim": {
+                "name": "Data Dimensions",
+                "description": "Data seq dimensions.",
+                "type": "array",
+                "minItems": 8,
+                "maxItems": 8,
+                "items": {
+                  "type": "integer"
+                }
+              },
+              "pixdim": {
+                "name": "Pixel Dimension",
+                "description": "Grid spacings (unit per dimension).",
+                "type": "array",
+                "minItems": 8,
+                "maxItems": 8,
+                "items": {
+                  "type": "number"
+                }
+              },
+              "xyzt_units": {
+                "name": "XYZT Units",
+                "description": "Units of pixdim[1..4]",
+                "type": "object",
+                "properties": {
+                  "xyz": {
+                    "name": "XYZ Units",
+                    "description": "String representing the unit of voxel spacing.",
+                    "type": "string",
+                    "enum": [
+                      "unknown",
+                      "meter",
+                      "mm",
+                      "um"
+                    ]
+                  },
+                  "t": {
+                    "name": "Time Unit",
+                    "description": "String representing the unit of inter-volume intervals.",
+                    "type": "string",
+                    "enum": [
+                      "unknown",
+                      "sec",
+                      "msec",
+                      "usec"
+                    ]
+                  }
+                }
+              },
+              "qform_code": {
+                "name": "qform code",
+                "description": "Use of the quaternion fields.",
+                "type": "integer"
+              },
+              "sform_code": {
+                "name": "sform code",
+                "description": "Use of the affine fields.",
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+    },
+    "expression_tests": [
+      {
+        "expression": "sidecar.MissingValue",
+        "result": null
+      },
+      {
+        "expression": "null.anything",
+        "result": null
+      },
+      {
+        "expression": "(null)",
+        "result": null
+      },
+      {
+        "expression": "null[0]",
+        "result": null
+      },
+      {
+        "expression": "null && true",
+        "result": null
+      },
+      {
+        "expression": "null || true",
+        "result": null
+      },
+      {
+        "expression": "!null",
+        "result": null
+      },
+      {
+        "expression": "intersects([], null)",
+        "result": null
+      },
+      {
+        "expression": "intersects(null, [])",
+        "result": null
+      },
+      {
+        "expression": "match(null, 'pattern')",
+        "result": null
+      },
+      {
+        "expression": "match('string', null)",
+        "result": null
+      },
+      {
+        "expression": "min(null)",
+        "result": null
+      },
+      {
+        "expression": "max(null)",
+        "result": null
+      },
+      {
+        "expression": "length(null)",
+        "result": null
+      },
+      {
+        "expression": "type(null)",
+        "result": "null"
+      },
+      {
+        "expression": "null == false",
+        "result": false
+      },
+      {
+        "expression": "null == true",
+        "result": false
+      },
+      {
+        "expression": "null != false",
+        "result": true
+      },
+      {
+        "expression": "null != true",
+        "result": true
+      },
+      {
+        "expression": "null != 1.5",
+        "result": true
+      },
+      {
+        "expression": "null == null",
+        "result": true
+      },
+      {
+        "expression": "null == 1",
+        "result": false
+      },
+      {
+        "expression": "\"VolumeTiming\" in null",
+        "result": false
+      },
+      {
+        "expression": "evaluate(true)",
+        "result": true
+      },
+      {
+        "expression": "evaluate(false)",
+        "result": false
+      },
+      {
+        "expression": "evaluate(null)",
+        "result": false
+      }
+    ]
+  },
+  "objects": {
+    "columns": {
+      "HED": {
+        "name": "HED",
+        "display_name": "HED Tag",
+        "description": "Hierarchical Event Descriptor (HED) Tag.\nSee the [HED Appendix](SPEC_ROOT/appendices/hed.md) for details.\n",
+        "type": "string"
+      },
+      "abbreviation": {
+        "name": "abbreviation",
+        "display_name": "Abbreviation",
+        "description": "The unique label abbreviation\n",
+        "type": "string"
+      },
+      "acq_time__scans": {
+        "name": "acq_time",
+        "display_name": "Scan acquisition time",
+        "description": "Acquisition time refers to when the first data point in each run was acquired.\nFurthermore, if this header is provided, the acquisition times of all files\nfrom the same recording MUST be identical.\nDatetime format and their anonymization are described in\n[Units](SPEC_ROOT/02-common-principles.md#units).\n",
+        "type": "string",
+        "format": "datetime"
+      },
+      "acq_time__sessions": {
+        "name": "acq_time",
+        "display_name": "Session acquisition time",
+        "description": "Acquisition time refers to when the first data point of the first run was acquired.\nDatetime format and their anonymization are described in\n[Units](SPEC_ROOT/02-common-principles.md#units).\n",
+        "type": "string",
+        "format": "datetime"
+      },
+      "age": {
+        "name": "age",
+        "display_name": "Subject age",
+        "description": "Numeric value in years (float or integer value).\n",
+        "type": "number",
+        "unit": "year"
+      },
+      "cardiac": {
+        "name": "cardiac",
+        "display_name": "Cardiac measurement",
+        "description": "continuous pulse measurement\n",
+        "type": "number"
+      },
+      "color": {
+        "name": "color",
+        "display_name": "Color label",
+        "description": "Hexadecimal. Label color for visualization.\n",
+        "type": "string",
+        "unit": "hexadecimal"
+      },
+      "detector__channels": {
+        "name": "detector",
+        "display_name": "Detector Name",
+        "description": "Name of the detector as specified in the `*_optodes.tsv` file.\n`n/a` for channels that do not contain NIRS signals (for example, acceleration).\n",
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "n/a"
+            ]
+          }
+        ]
+      },
+      "detector_type": {
+        "name": "detector_type",
+        "display_name": "Detector Type",
+        "description": "The type of detector. Only to be used if the field `DetectorType` in `*_nirs.json` is set to `mixed`.\n",
+        "anyOf": [
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "derived_from": {
+        "name": "derived_from",
+        "display_name": "Derived from",
+        "description": "`sample-<label>` entity from which a sample is derived,\nfor example a slice of tissue (`sample-02`) derived from a block of tissue (`sample-01`).\n",
+        "type": "string",
+        "pattern": "^sample-[0-9a-zA-Z]+$"
+      },
+      "description": {
+        "name": "description",
+        "display_name": "Description",
+        "description": "Brief free-text description of the channel, or other information of interest.\n",
+        "type": "string"
+      },
+      "description__optode": {
+        "name": "description",
+        "display_name": "Description",
+        "description": "Free-form text description of the optode, or other information of interest.\n",
+        "type": "string"
+      },
+      "dimension": {
+        "name": "dimension",
+        "display_name": "Dimension",
+        "description": "Size of the group (grid/strip/probe) that this electrode belongs to.\nMust be of form `[AxB]` with the smallest dimension first (for example, `[1x8]`).\n",
+        "type": "string"
+      },
+      "duration": {
+        "name": "duration",
+        "display_name": "Event duration",
+        "description": "Duration of the event (measured from onset) in seconds.\nMust always be either zero or positive (or `n/a` if unavailable).\nA \"duration\" value of zero implies that the delta function or event is so\nshort as to be effectively modeled as an impulse.\n",
+        "anyOf": [
+          {
+            "type": "number",
+            "unit": "s",
+            "minimum": 0
+          },
+          {
+            "type": "string",
+            "enum": [
+              "n/a"
+            ]
+          }
+        ]
+      },
+      "filename": {
+        "name": "filename",
+        "display_name": "Filename",
+        "description": "Relative paths to files.\n",
+        "type": "string",
+        "format": "participant_relative"
+      },
+      "group__channel": {
+        "name": "group",
+        "display_name": "Channel group",
+        "description": "Which group of channels (grid/strip/seeg/depth) this channel belongs to.\nThis is relevant because one group has one cable-bundle and noise can be shared.\nThis can be a name or number.\n",
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      },
+      "handedness": {
+        "name": "handedness",
+        "display_name": "Subject handedness",
+        "description": "String value indicating one of \"left\", \"right\", \"ambidextrous\".\n\nFor \"left\", use one of these values: `left`, `l`, `L`, `LEFT`, `Left`.\n\nFor \"right\", use one of these values: `right`, `r`, `R`, `RIGHT`, `Right`.\n\nFor \"ambidextrous\", use one of these values: `ambidextrous`, `a`, `A`, `AMBIDEXTROUS`,\n`Ambidextrous`.\n",
+        "type": "string",
+        "enum": [
+          "left",
+          "l",
+          "L",
+          "LEFT",
+          "Left",
+          "right",
+          "r",
+          "R",
+          "RIGHT",
+          "Right",
+          "ambidextrous",
+          "a",
+          "A",
+          "AMBIDEXTROUS",
+          "Ambidextrous",
+          "n/a"
+        ]
+      },
+      "hemisphere": {
+        "name": "hemisphere",
+        "display_name": "Electrode hemisphere",
+        "description": "The hemisphere in which the electrode is placed.\n",
+        "type": "string",
+        "enum": [
+          "L",
+          "R"
+        ]
+      },
+      "high_cutoff": {
+        "name": "high_cutoff",
+        "display_name": "High cutoff",
+        "description": "Frequencies used for the low-pass filter applied to the channel in Hz.\nIf no low-pass filter applied, use `n/a`.\nNote that hardware anti-aliasing in A/D conversion of all MEG/EEG electronics\napplies a low-pass filter; specify its frequency here if applicable.\n",
+        "anyOf": [
+          {
+            "type": "number",
+            "unit": "Hz",
+            "minimum": 0
+          },
+          {
+            "type": "string",
+            "enum": [
+              "n/a"
+            ]
+          }
+        ]
+      },
+      "hplc_recovery_fractions": {
+        "name": "hplc_recovery_fractions",
+        "display_name": "HPLC recovery fractions",
+        "description": "HPLC recovery fractions (the fraction of activity that gets loaded onto the HPLC).\n",
+        "type": "number",
+        "unit": "arbitrary"
+      },
+      "impedance": {
+        "name": "impedance",
+        "display_name": "Electrode impedance",
+        "description": "Impedance of the electrode, units MUST be in `kOhm`.\n",
+        "type": "number",
+        "unit": "kOhm"
+      },
+      "index": {
+        "name": "index",
+        "display_name": "Label index",
+        "description": "The label integer index.\n",
+        "type": "integer"
+      },
+      "low_cutoff": {
+        "name": "low_cutoff",
+        "display_name": "Low cutoff",
+        "description": "Frequencies used for the high-pass filter applied to the channel in Hz.\nIf no high-pass filter applied, use `n/a`.\n",
+        "anyOf": [
+          {
+            "type": "number",
+            "unit": "Hz"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "n/a"
+            ]
+          }
+        ]
+      },
+      "manufacturer": {
+        "name": "manufacturer",
+        "display_name": "Manufacturer",
+        "description": "The manufacturer for each electrode.\nCan be used if electrodes were manufactured by more than one company.\n",
+        "type": "string"
+      },
+      "mapping": {
+        "name": "mapping",
+        "display_name": "Label mapping",
+        "description": "Corresponding integer label in the standard BIDS label lookup.\n",
+        "type": "integer"
+      },
+      "material": {
+        "name": "material",
+        "display_name": "Electrode material",
+        "description": "Material of the electrode (for example, `Tin`, `Ag/AgCl`, `Gold`).\n",
+        "type": "string"
+      },
+      "metabolite_parent_fraction": {
+        "name": "metabolite_parent_fraction",
+        "display_name": "Metabolite parent fraction",
+        "description": "Parent fraction of the radiotracer (0-1).\n",
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1
+      },
+      "metabolite_polar_fraction": {
+        "name": "metabolite_polar_fraction",
+        "display_name": "Metabolite polar fraction",
+        "description": "Polar metabolite fraction of the radiotracer (0-1).\n",
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1
+      },
+      "name__channels": {
+        "name": "name",
+        "display_name": "Channel name",
+        "description": "Label of the channel.\n",
+        "type": "string"
+      },
+      "name__electrodes": {
+        "name": "name",
+        "display_name": "Electrode name",
+        "description": "Name of the electrode contact point.\n",
+        "type": "string"
+      },
+      "name__optodes": {
+        "name": "name",
+        "display_name": "Optode name",
+        "description": "Name of the optode, must be unique.\n",
+        "type": "string"
+      },
+      "name__segmentations": {
+        "name": "name",
+        "display_name": "Label name",
+        "description": "The unique label name.\n",
+        "type": "string"
+      },
+      "notch": {
+        "name": "notch",
+        "display_name": "Notch frequencies",
+        "description": "Frequencies used for the notch filter applied to the channel, in Hz.\nIf no notch filter applied, use `n/a`.\n",
+        "anyOf": [
+          {
+            "type": "number",
+            "unit": "Hz"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "n/a"
+            ]
+          }
+        ]
+      },
+      "onset": {
+        "name": "onset",
+        "display_name": "Event onset",
+        "description": "Onset (in seconds) of the event, measured from the beginning of the acquisition\nof the first data point stored in the corresponding task data file.\nNegative onsets are allowed, to account for events that occur prior to the first\nstored data point.\nFor example, in case there is an in-scanner training phase that begins before\nthe scanning sequence has started events from this sequence should have\nnegative onset time counting down to the beginning of the acquisition of the\nfirst volume.\n\nIf any data points have been discarded before forming the data file\n(for example, \"dummy volumes\" in BOLD fMRI),\na time of 0 corresponds to the first stored data point and not the first\nacquired data point.\n",
+        "type": "number",
+        "unit": "s"
+      },
+      "orientation_component": {
+        "name": "orientation_component",
+        "display_name": "Orientation Component",
+        "description": "Description of the orientation of the channel.\n",
+        "type": "string",
+        "enum": [
+          "x",
+          "y",
+          "z"
+        ]
+      },
+      "pathology": {
+        "name": "pathology",
+        "display_name": "Pathology",
+        "description": "String value describing the pathology of the sample or type of control.\nWhen different from `healthy`, pathology SHOULD be specified.\nThe pathology may be specified in either `samples.tsv` or\n`sessions.tsv`, depending on whether the pathology changes over time.\n",
+        "type": "string"
+      },
+      "participant_id": {
+        "name": "participant_id",
+        "display_name": "Participant ID",
+        "description": "A participant identifier of the form `sub-<label>`,\nmatching a participant entity found in the dataset.\n",
+        "type": "string",
+        "pattern": "^sub-[0-9a-zA-Z]+$"
+      },
+      "plasma_radioactivity": {
+        "name": "plasma_radioactivity",
+        "display_name": "Plasma radioactivity",
+        "description": "Radioactivity in plasma, in unit of plasma radioactivity (for example, `kBq/mL`).\n",
+        "type": "number"
+      },
+      "reference__eeg": {
+        "name": "reference",
+        "display_name": "Electrode reference",
+        "description": "Name of the reference electrode(s).\nThis column is not needed when it is common to all channels.\nIn that case the reference electrode(s) can be specified in `*_eeg.json` as `EEGReference`).\n",
+        "type": "string"
+      },
+      "reference__ieeg": {
+        "name": "reference",
+        "display_name": "Electrode reference",
+        "description": "Specification of the reference (for example, `mastoid`, `ElectrodeName01`, `intracranial`, `CAR`, `other`, `n/a`).\nIf the channel is not an electrode channel (for example, a microphone channel) use `n/a`.\n",
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "n/a"
+            ]
+          }
+        ]
+      },
+      "respiratory": {
+        "name": "respiratory",
+        "display_name": "Respiratory measurement",
+        "description": "continuous breathing measurement\n",
+        "type": "number"
+      },
+      "response_time": {
+        "name": "response_time",
+        "display_name": "Response time",
+        "description": "Response time measured in seconds.\nA negative response time can be used to represent preemptive responses and\n`n/a` denotes a missed response.\n",
+        "anyOf": [
+          {
+            "type": "number",
+            "unit": "s"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "n/a"
+            ]
+          }
+        ]
+      },
+      "sample": {
+        "name": "sample",
+        "display_name": "Sample index",
+        "description": "Onset of the event according to the sampling scheme of the recorded modality\n(that is, referring to the raw data file that the `events.tsv` file accompanies).\nWhen there are several sampling schemes present in the raw data file (as can be\nthe case for example for `.edf` files), this column is ambiguous and\nSHOULD NOT be used.\n",
+        "type": "integer"
+      },
+      "sample_id": {
+        "name": "sample_id",
+        "display_name": "Sample ID",
+        "description": "A sample identifier of the form `sample-<label>`,\nmatching a sample entity found in the dataset.\n",
+        "type": "string",
+        "pattern": "^sample-[0-9a-zA-Z]+$"
+      },
+      "sample_type": {
+        "name": "sample_type",
+        "display_name": "Sample type",
+        "description": "Biosample type defined by\n[ENCODE Biosample Type](https://www.encodeproject.org/profiles/biosample_type).\n",
+        "type": "string",
+        "enum": [
+          "cell line",
+          "in vitro differentiated cells",
+          "primary cell",
+          "cell-free sample",
+          "cloning host",
+          "tissue",
+          "whole organisms",
+          "organoid",
+          "technical sample"
+        ]
+      },
+      "sampling_frequency": {
+        "name": "sampling_frequency",
+        "display_name": "Channel sampling frequency",
+        "description": "Sampling rate of the channel in Hz.\n",
+        "type": "number",
+        "unit": "Hz"
+      },
+      "session_id": {
+        "name": "session_id",
+        "display_name": "Session ID",
+        "description": "A session identifier of the form `ses-<label>`,\nmatching a session found in the dataset.\n",
+        "type": "string",
+        "pattern": "^ses-[0-9a-zA-Z]+$"
+      },
+      "sex": {
+        "name": "sex",
+        "display_name": "Sex",
+        "description": "String value indicating phenotypical sex, one of \"male\", \"female\", \"other\".\n\nFor \"male\", use one of these values: `male`, `m`, `M`, `MALE`, `Male`.\n\nFor \"female\", use one of these values: `female`, `f`, `F`, `FEMALE`, `Female`.\n\nFor \"other\", use one of these values: `other`, `o`, `O`, `OTHER`, `Other`.\n",
+        "type": "string",
+        "enum": [
+          "male",
+          "m",
+          "M",
+          "MALE",
+          "Male",
+          "female",
+          "f",
+          "F",
+          "FEMALE",
+          "Female",
+          "other",
+          "o",
+          "O",
+          "OTHER",
+          "Other",
+          "n/a"
+        ]
+      },
+      "short_channel": {
+        "name": "short_channel",
+        "display_name": "Short Channel",
+        "description": "Is the channel designated as short.\nThe total number of channels listed as short channels\nSHOULD be stored in `ShortChannelCount` in `*_nirs.json`.\n",
+        "type": "boolean"
+      },
+      "size": {
+        "name": "size",
+        "display_name": "Electrode size",
+        "description": "Surface area of the electrode, units MUST be in `mm^2`.\n",
+        "type": "number",
+        "unit": "mm^2"
+      },
+      "software_filters": {
+        "name": "software_filters",
+        "display_name": "Software filters",
+        "description": "List of temporal and/or spatial software filters applied\n(for example, `SSS`, `SpatialCompensation`).\nNote that parameters should be defined in the general MEG sidecar .json file.\nIndicate `n/a` in the absence of software filters applied.\n",
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "n/a"
+            ]
+          }
+        ]
+      },
+      "source__channels": {
+        "name": "source",
+        "display_name": "Source name",
+        "description": "Name of the source as specified in the `*_optodes.tsv` file.\n`n/a` for channels that do not contain fNIRS signals (for example, acceleration).\n",
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "n/a"
+            ]
+          }
+        ]
+      },
+      "source__optodes": {
+        "name": "source_type",
+        "display_name": "Source type",
+        "description": "The type of source. Only to be used if the field `SourceType` in `*_nirs.json` is set to `mixed`.\n",
+        "anyOf": [
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "species": {
+        "name": "species",
+        "display_name": "Species",
+        "description": "The `species` column SHOULD be a binomial species name from the\n[NCBI Taxonomy](https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi)\n(for example, `homo sapiens`, `mus musculus`, `rattus norvegicus`).\nFor backwards compatibility, if `species` is absent, the participant is assumed to be\n`homo sapiens`.\n",
+        "type": "string"
+      },
+      "status": {
+        "name": "status",
+        "display_name": "Channel status",
+        "description": "Data quality observed on the channel.\nA channel is considered `bad` if its data quality is compromised by excessive noise.\nIf quality is unknown, then a value of `n/a` may be used.\nDescription of noise type SHOULD be provided in `[status_description]`.\n",
+        "type": "string",
+        "enum": [
+          "good",
+          "bad",
+          "n/a"
+        ]
+      },
+      "status_description": {
+        "name": "status_description",
+        "display_name": "Channel status description",
+        "description": "Freeform text description of noise or artifact affecting data quality on the channel.\nIt is meant to explain why the channel was declared bad in the `status` column.\n",
+        "type": "string"
+      },
+      "stim_file": {
+        "name": "stim_file",
+        "display_name": "Stimulus file",
+        "description": "Represents the location of the stimulus file (such as an image, video, or\naudio file) presented at the given onset time.\nThere are no restrictions on the file formats of the stimuli files,\nbut they should be stored in the `/stimuli` directory\n(under the root directory of the dataset; with optional subdirectories).\nThe values under the `stim_file` column correspond to a path relative to\n`/stimuli`.\nFor example `images/cat03.jpg` will be translated to `/stimuli/images/cat03.jpg`.\n",
+        "type": "string",
+        "format": "stimuli_relative"
+      },
+      "strain": {
+        "name": "strain",
+        "display_name": "Strain",
+        "description": "For species different from `homo sapiens`, string value indicating\nthe strain of the species, for example: `C57BL/6J`.\n",
+        "type": "string"
+      },
+      "strain_rrid": {
+        "name": "strain_rrid",
+        "display_name": "Strain RRID",
+        "description": "For species different from `homo sapiens`, research resource identifier\n([RRID](https://scicrunch.org/resources/Organisms/search))\nof the strain of the species, for example: `RRID:IMSR_JAX:000664`.\n",
+        "type": "string",
+        "format": "rrid"
+      },
+      "time": {
+        "name": "time",
+        "display_name": "Time",
+        "description": "Time, in seconds, relative to `TimeZero` defined by the `*_pet.json`.\nFor example, 5.\n",
+        "type": "number",
+        "unit": "s"
+      },
+      "trial_type": {
+        "name": "trial_type",
+        "display_name": "Trial type",
+        "description": "Primary categorisation of each trial to identify them as instances of the\nexperimental conditions.\nFor example: for a response inhibition task, it could take on values `go` and\n`no-go` to refer to response initiation and response inhibition experimental\nconditions.\n",
+        "type": "string"
+      },
+      "trigger": {
+        "name": "trigger",
+        "display_name": "Trigger",
+        "description": "continuous measurement of the scanner trigger signal\n",
+        "type": "number"
+      },
+      "type__eeg_channels": {
+        "name": "type",
+        "display_name": "Channel type",
+        "description": "Type of channel; MUST use the channel types listed below.\nNote that the type MUST be in upper-case.\n",
+        "type": "string",
+        "enum": [
+          "AUDIO",
+          "EEG",
+          "EOG",
+          "ECG",
+          "EMG",
+          "EYEGAZE",
+          "GSR",
+          "HEOG",
+          "MISC",
+          "PPG",
+          "PUPIL",
+          "REF",
+          "RESP",
+          "SYSCLOCK",
+          "TEMP",
+          "TRIG",
+          "VEOG"
+        ]
+      },
+      "type__meg_channels": {
+        "name": "type",
+        "display_name": "Channel type",
+        "description": "Type of channel; MUST use the channel types listed below.\nNote that the type MUST be in upper-case.\n",
+        "type": "string",
+        "enum": [
+          "MEGMAG",
+          "MEGGRADAXIAL",
+          "MEGGRADPLANAR",
+          "MEGREFMAG",
+          "MEGREFGRADAXIAL",
+          "MEGREFGRADPLANAR",
+          "MEGOTHER",
+          "EEG",
+          "ECOG",
+          "SEEG",
+          "DBS",
+          "VEOG",
+          "HEOG",
+          "EOG",
+          "ECG",
+          "EMG",
+          "TRIG",
+          "AUDIO",
+          "PD",
+          "EYEGAZE",
+          "PUPIL",
+          "MISC",
+          "SYSCLOCK",
+          "ADC",
+          "DAC",
+          "HLU",
+          "FITERR",
+          "OTHER"
+        ]
+      },
+      "type__ieeg_channels": {
+        "name": "type",
+        "display_name": "Channel type",
+        "description": "Type of channel; MUST use the channel types listed below.\nNote that the type MUST be in upper-case.\n",
+        "type": "string",
+        "enum": [
+          "EEG",
+          "ECOG",
+          "SEEG",
+          "DBS",
+          "VEOG",
+          "HEOG",
+          "EOG",
+          "ECG",
+          "EMG",
+          "TRIG",
+          "AUDIO",
+          "PD",
+          "EYEGAZE",
+          "PUPIL",
+          "MISC",
+          "SYSCLOCK",
+          "ADC",
+          "DAC",
+          "REF",
+          "OTHER"
+        ]
+      },
+      "type__nirs_channels": {
+        "name": "type",
+        "display_name": "Channel type",
+        "description": "Type of channel; MUST use the channel types listed below.\nNote that the type MUST be in upper-case.\n",
+        "type": "string",
+        "enum": [
+          "NIRSCWAMPLITUDE",
+          "NIRSCWFLUORESCENSEAMPLITUDE",
+          "NIRSCWOPTICALDENSITY",
+          "NIRSCWHBO",
+          "NIRSCWHBR",
+          "NIRSCWMUA",
+          "MEGMAG",
+          "MEGGRADAXIAL",
+          "MEGGRADPLANAR",
+          "MEGREFMAG",
+          "MEGREFGRADAXIAL",
+          "MEGREFGRADPLANAR",
+          "MEGOTHER",
+          "EEG",
+          "ECOG",
+          "SEEG",
+          "DBS",
+          "VEOG",
+          "HEOG",
+          "EOG",
+          "ECG",
+          "EMG",
+          "TRIG",
+          "AUDIO",
+          "PD",
+          "EYEGAZE",
+          "PUPIL",
+          "MISC",
+          "SYSCLOCK",
+          "ADC",
+          "DAC",
+          "HLU",
+          "FITERR",
+          "ACCEL",
+          "GYRO",
+          "MAGN",
+          "MISC",
+          "OTHER"
+        ]
+      },
+      "type__electrodes": {
+        "name": "type",
+        "display_name": "Electrode type",
+        "description": "Type of the electrode (for example, cup, ring, clip-on, wire, needle).\n",
+        "type": "string"
+      },
+      "type__optodes": {
+        "name": "type",
+        "display_name": "Type",
+        "description": "The type of the optode.\n",
+        "type": "string",
+        "enum": [
+          "source",
+          "detector",
+          "n/a"
+        ]
+      },
+      "units": {
+        "name": "units",
+        "display_name": "Units",
+        "description": "Physical unit of the value represented in this channel,\nfor example, `V` for Volt, or `fT/cm` for femto Tesla per centimeter\n(see [Units](SPEC_ROOT/02-common-principles.md#units)).\n",
+        "type": "string",
+        "format": "unit"
+      },
+      "units__nirs": {
+        "name": "units",
+        "display_name": "Units",
+        "description": "Physical unit of the value represented in this channel,\nspecified according to the SI unit symbol and possibly prefix symbol,\nor as a derived SI unit (for example, `V`, or unitless for changes in optical densities).\nFor guidelines about units see the [Appendix](SPEC_ROOT/appendices/units.md)\nand [Common Principles](SPEC_ROOT/02-common-principles.md#units) pages.\n",
+        "type": "string",
+        "format": "unit"
+      },
+      "value": {
+        "name": "value",
+        "display_name": "Marker value",
+        "description": "Marker value associated with the event (for example, the value of a TTL\ntrigger that was recorded at the onset of the event).\n",
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      },
+      "volume_type": {
+        "name": "volume_type",
+        "display_name": "ASL volume type",
+        "description": "The `*_aslcontext.tsv` table consists of a single column of labels identifying\nthe `volume_type` of each volume in the corresponding `*_asl.nii[.gz]` file.\n",
+        "type": "string",
+        "enum": [
+          "control",
+          "label",
+          "m0scan",
+          "deltam",
+          "cbf"
+        ]
+      },
+      "wavelength_nominal": {
+        "name": "wavelength_nominal",
+        "display_name": "Wavelength nominal",
+        "description": "Specified wavelength of light in nm.\n`n/a` for channels that do not contain raw NIRS signals (for example, acceleration).\nThis field is equivalent to `/nirs(i)/probe/wavelengths` in the SNIRF specification.\n",
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "n/a"
+            ]
+          }
+        ]
+      },
+      "wavelength_actual": {
+        "name": "wavelength_actual",
+        "display_name": "Wavelength actual",
+        "description": "Measured wavelength of light in nm.\n`n/a` for channels that do not contain raw NIRS signals (acceleration).\nThis field is equivalent to `measurementList.wavelengthActual` in the SNIRF specification.\n",
+        "type": "number"
+      },
+      "wavelength_emission_actual": {
+        "name": "wavelength_emission_actual",
+        "display_name": "Wavelength emission actual",
+        "description": "Measured emission wavelength of light in nm.\n`n/a` for channels that do not contain raw NIRS signals (acceleration).\nThis field is equivalent to `measurementList.wavelengthEmissionActual` in the SNIRF specification.\n",
+        "type": "number"
+      },
+      "whole_blood_radioactivity": {
+        "name": "whole_blood_radioactivity",
+        "display_name": "Whole blood radioactivity",
+        "description": "Radioactivity in whole blood samples,\nin unit of radioactivity measurements in whole blood samples (for example, `kBq/mL`).\n",
+        "type": "number"
+      },
+      "x": {
+        "name": "x",
+        "display_name": "X position",
+        "description": "Recorded position along the x-axis.\n",
+        "type": "number"
+      },
+      "y": {
+        "name": "y",
+        "display_name": "Y position",
+        "description": "Recorded position along the y-axis.\n",
+        "type": "number"
+      },
+      "z": {
+        "name": "z",
+        "display_name": "Z position",
+        "description": "Recorded position along the z-axis.\n",
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "n/a"
+            ]
+          }
+        ]
+      },
+      "x__optodes": {
+        "name": "x",
+        "display_name": "X position",
+        "description": "Recorded position along the x-axis.\n`\"n/a\"` if not available.\n",
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "n/a"
+            ]
+          }
+        ]
+      },
+      "y__optodes": {
+        "name": "y",
+        "display_name": "Y position",
+        "description": "Recorded position along the y-axis.\n`\"n/a\"` if not available.\n",
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "n/a"
+            ]
+          }
+        ]
+      },
+      "z__optodes": {
+        "name": "z",
+        "display_name": "Z position",
+        "description": "Recorded position along the z-axis.\n`\"n/a\"` if not available.\n",
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "n/a"
+            ]
+          }
+        ]
+      },
+      "template_x": {
+        "name": "template_x",
+        "display_name": "X template position",
+        "description": "Assumed or ideal position along the x axis.\n",
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "n/a"
+            ]
+          }
+        ]
+      },
+      "template_y": {
+        "name": "template_y",
+        "display_name": "Y template position",
+        "description": "Assumed or ideal position along the y axis.\n",
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "n/a"
+            ]
+          }
+        ]
+      },
+      "template_z": {
+        "name": "template_z",
+        "display_name": "Z template position",
+        "description": "Assumed or ideal position along the z axis.\n",
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "n/a"
+            ]
+          }
+        ]
+      }
+    },
+    "common_principles": {
+      "data_acquisition": {
+        "name": "Data acquisition",
+        "display_name": "Data acquisition",
+        "description": "A continuous uninterrupted block of time during which a brain scanning instrument was acquiring data according to\nparticular scanning sequence/protocol.\n"
+      },
+      "data_type": {
+        "name": "Data type",
+        "display_name": "Data type",
+        "description": "A functional group of different types of data.\nData files are contained in a directory named for the data type.\nIn raw datasets, the data type directory is nested inside subject and (optionally) session directories.\nBIDS defines the following data types:\n\n    1.  `func` (task based and resting state functional MRI)\n\n    2.  `dwi` (diffusion weighted imaging)\n\n    3.  `fmap` (field inhomogeneity mapping data such as field maps)\n\n    4.  `anat` (structural imaging such as T1, T2, PD, and so on)\n\n    5.  `perf` (perfusion)\n\n    6.  `meg` (magnetoencephalography)\n\n    7.  `eeg` (electroencephalography)\n\n    8.  `ieeg` (intracranial electroencephalography)\n\n    9.  `beh` (behavioral)\n\n    10. `pet` (positron emission tomography)\n\n    11. `micr` (microscopy)\n\n    12. `nirs` (near infrared spectroscopy)\n"
+      },
+      "dataset": {
+        "name": "Dataset",
+        "display_name": "Dataset",
+        "description": "A set of neuroimaging and behavioral data acquired for a purpose of a particular study.\nA dataset consists of data acquired from one or more subjects, possibly from multiple sessions.\n"
+      },
+      "deprecated": {
+        "name": "DEPRECATED",
+        "display_name": "DEPRECATED",
+        "description": "A \"deprecated\" entity or metadata field SHOULD NOT be used in the generation of new datasets.\nIt remains in the standard in order to preserve the interpretability of existing datasets.\nValidating software SHOULD warn when deprecated practices are detected\nand provide a suggestion for updating the dataset to preserve the curator's intent.\n"
+      },
+      "event": {
+        "name": "Event",
+        "display_name": "Event",
+        "description": "Something that happens or may be perceived by a test subject as happening\nat a particular instant during the recording.\nEvents are most commonly associated with on- or offset of stimulus presentations,\nor with the distinct marker of on- or offset of a subject's response or motor action.\nOther events may include unplanned incidents\n(for example, sudden onset of noise and vibrations due to construction work,\nlaboratory device malfunction),\nchanges in task instructions (for example, switching the response hand),\nor experiment control parameters (for example, changing the stimulus presentation rate over experimental blocks),\nand noted data feature occurrences (for example, a recording electrode producing noise).\nIn BIDS, each event has an onset time and duration.\nNote that not all tasks will have recorded events (for example, \"resting state\").\n"
+      },
+      "extension": {
+        "name": "File extension",
+        "display_name": "File extension",
+        "description": "A portion of the file name after the left-most period (`.`) preceded by any other alphanumeric.\nFor example, `.gitignore` does not have a file extension,\nbut the file extension of `test.nii.gz` is `.nii.gz`.\nNote that the left-most period is included in the file extension.\n"
+      },
+      "index": {
+        "name": "index",
+        "display_name": "index",
+        "description": "A nonnegative integer, possibly prefixed with arbitrary number of 0s for consistent indentation,\nfor example, it is `01` in `run-01` following `run-<index>` specification.\n"
+      },
+      "label": {
+        "name": "label",
+        "display_name": "label",
+        "description": "An alphanumeric value, possibly prefixed with arbitrary number of 0s for consistent indentation,\nfor example, it is `rest` in `task-rest` following `task-<label>` specification.\nNote that labels MUST not collide when casing is ignored\n(see [Case collision intolerance](SPEC_ROOT/02-common-principles.md#case-collision-intolerance)).\n"
+      },
+      "modality": {
+        "name": "Modality",
+        "display_name": "Modality",
+        "description": "The category of brain data recorded by a file.\nFor MRI data, different pulse sequences are considered distinct modalities,\nsuch as `T1w`, `bold` or `dwi`.\nFor passive recording techniques, such as EEG, MEG or iEEG,\nthe technique is sufficiently uniform to define the modalities `eeg`, `meg` and `ieeg`.\nWhen applicable, the modality is indicated in the **suffix**.\nThe modality may overlap with, but should not be confused with the **data type**.\n"
+      },
+      "run": {
+        "name": "Run",
+        "display_name": "Run",
+        "description": "An uninterrupted repetition of data acquisition that has the same acquisition parameters and task\n(however events can change from run to run due to different subject response\nor randomized nature of the stimuli).\nRun is a synonym of a data acquisition.\nNote that \"uninterrupted\" may look different by modality due to the nature of the recording.\nFor example, in [MRI](SPEC_ROOT/04-modality-specific-files/01-magnetic-resonance-imaging-data.md)\nor [MEG](SPEC_ROOT/04-modality-specific-files/02-magnetoencephalography.md),\nif a subject leaves the scanner, the acquisition must be restarted.\nFor some types of [PET](SPEC_ROOT/04-modality-specific-files/09-positron-emission-tomography.md) acquisitions,\na subject may leave and re-enter the scanner without interrupting the scan.\n"
+      },
+      "sample": {
+        "name": "Sample",
+        "display_name": "Sample",
+        "description": "A sample pertaining to a subject such as tissue, primary cell or cell-free sample.\nSample labels MUST be unique within a subject and it is RECOMMENDED\nthat they be unique throughout the dataset.\n"
+      },
+      "session": {
+        "name": "Session",
+        "display_name": "Session",
+        "description": "A logical grouping of neuroimaging and behavioral data consistent across subjects.\nSession can (but doesn't have to) be synonymous to a visit in a longitudinal study.\nIn general, subjects will stay in the scanner during one session.\nHowever, for example, if a subject has to leave the scanner room\nand then be re-positioned on the scanner bed,\nthe set of MRI acquisitions will still be considered as a session\nand match sessions acquired in other subjects.\nSimilarly, in situations where different data types are obtained over several visits\n(for example fMRI on one day followed by DWI the day after) those can be grouped in one session.\nDefining multiple sessions is appropriate when several identical or similar data acquisitions\nare planned and performed on all -or most- subjects,\noften in the case of some intervention between sessions (for example, training).\nIn the [PET](SPEC_ROOT/04-modality-specific-files/09-positron-emission-tomography.md) context,\na session may also indicate a group of related scans, taken in one or more visits.\n"
+      },
+      "suffix": {
+        "name": "suffix",
+        "display_name": "suffix",
+        "description": "An alphanumeric string that forms part of a filename, located after all\n[entities](SPEC_ROOT/02-common-principles.md#entities) and\nfollowing a final `_`, right before the **file extension**;\nfor example, it is `eeg` in `sub-05_task-matchingpennies_eeg.vhdr`.\n"
+      },
+      "subject": {
+        "name": "Subject",
+        "display_name": "Subject",
+        "description": "A person or animal participating in the study.\nUsed interchangeably with term **Participant**.\n"
+      },
+      "task": {
+        "name": "Task",
+        "display_name": "Task",
+        "description": "A set of structured activities performed by the participant.\nTasks are usually accompanied by stimuli and responses, and can greatly vary in complexity.\nFor the purpose of this specification we consider the so-called \"resting state\" a task.\nIn the context of brain scanning, a task is always tied to one data acquisition.\nTherefore, even if during one acquisition the subject performed multiple conceptually different behaviors\n(with different sets of instructions) they will be considered one (combined) task.\n"
+      }
+    },
+    "datatypes": {
+      "anat": {
+        "value": "anat",
+        "display_name": "Anatomical Magnetic Resonance Imaging",
+        "description": "Magnetic resonance imaging sequences designed to characterize static, anatomical features.\n"
+      },
+      "beh": {
+        "value": "beh",
+        "display_name": "Behavioral Data",
+        "description": "Behavioral data.\n"
+      },
+      "dwi": {
+        "value": "dwi",
+        "display_name": "Diffusion-Weighted Imaging",
+        "description": "Diffusion-weighted imaging (DWI).\n"
+      },
+      "eeg": {
+        "value": "eeg",
+        "display_name": "Electroencephalography",
+        "description": "Electroencephalography"
+      },
+      "fmap": {
+        "value": "fmap",
+        "display_name": "Field maps",
+        "description": "MRI scans for estimating B0 inhomogeneity-induced distortions.\n"
+      },
+      "func": {
+        "value": "func",
+        "display_name": "Task-Based Magnetic Resonance Imaging",
+        "description": "Task (including resting state) imaging data\n"
+      },
+      "ieeg": {
+        "value": "ieeg",
+        "display_name": "Intracranial electroencephalography",
+        "description": "Intracranial electroencephalography (iEEG) or electrocorticography (ECoG) data\n"
+      },
+      "meg": {
+        "value": "meg",
+        "display_name": "Magnetoencephalography",
+        "description": "Magnetoencephalography"
+      },
+      "micr": {
+        "value": "micr",
+        "display_name": "Microscopy",
+        "description": "Microscopy"
+      },
+      "perf": {
+        "value": "perf",
+        "display_name": "Perfusion imaging",
+        "description": "Blood perfusion imaging data, including arterial spin labeling (ASL)\n"
+      },
+      "pet": {
+        "value": "pet",
+        "display_name": "Positron Emission Tomography",
+        "description": "Positron emission tomography data\n"
+      },
+      "nirs": {
+        "value": "nirs",
+        "display_name": "Near-Infrared Spectroscopy",
+        "description": "Near-Infrared Spectroscopy data organized around the SNIRF format"
+      }
+    },
+    "entities": {
+      "acquisition": {
+        "name": "acq",
+        "display_name": "Acquisition",
+        "description": "The `acq-<label>` entity corresponds to a custom label the user MAY use to distinguish\na different set of parameters used for acquiring the same modality.\n\nFor example, this should be used when a study includes two T1w images -\none full brain low resolution and one restricted field of view but high resolution.\nIn such case two files could have the following names:\n`sub-01_acq-highres_T1w.nii.gz` and `sub-01_acq-lowres_T1w.nii.gz`;\nhowever, the user is free to choose any other label than `highres` and `lowres` as long\nas they are consistent across subjects and sessions.\n\nIn case different sequences are used to record the same modality\n(for example, `RARE` and `FLASH` for T1w)\nthis field can also be used to make that distinction.\nThe level of detail at which the distinction is made\n(for example, just between `RARE` and `FLASH`, or between `RARE`, `FLASH`, and `FLASHsubsampled`)\nremains at the discretion of the researcher.\n",
+        "type": "string",
+        "format": "label"
+      },
+      "atlas": {
+        "name": "atlas",
+        "display_name": "Atlas",
+        "description": "The `atlas-<label>` key/value pair corresponds to a custom label the user\nMAY use to distinguish a different atlas used for similar type of data.\n\nThis entity is only applicable to derivative data.\n",
+        "type": "string",
+        "format": "label"
+      },
+      "ceagent": {
+        "name": "ce",
+        "display_name": "Contrast Enhancing Agent",
+        "description": "The `ce-<label>` entity can be used to distinguish sequences using different contrast enhanced images.\nThe label is the name of the contrast agent.\n\nThis entity represents the `\"ContrastBolusIngredient\"` metadata field.\nTherefore, if the `ce-<label>` entity is present in a filename,\n`\"ContrastBolusIngredient\"` MAY also be added in the JSON file, with the same label.\n",
+        "type": "string",
+        "format": "label"
+      },
+      "chunk": {
+        "name": "chunk",
+        "display_name": "Chunk",
+        "description": "The `chunk-<index>` key/value pair is used to distinguish between different regions,\n2D images or 3D volumes files,\nof the same physical sample with different fields of view acquired in the same imaging experiment.\n",
+        "type": "string",
+        "format": "index"
+      },
+      "density": {
+        "name": "den",
+        "display_name": "Density",
+        "description": "Density of non-parametric surfaces.\n\nThis entity represents the `\"Density\"` metadata field.\nTherefore, if the `den-<label>` entity is present in a filename,\n`\"Density\"` MUST also be added in the JSON file, to provide interpretation.\n\nThis entity is only applicable to derivative data.\n",
+        "type": "string",
+        "format": "label"
+      },
+      "description": {
+        "name": "desc",
+        "display_name": "Description",
+        "description": "When necessary to distinguish two files that do not otherwise have a\ndistinguishing entity, the `desc-<label>` entity SHOULD be used.\n\nThis entity is only applicable to derivative data.\n",
+        "type": "string",
+        "format": "label"
+      },
+      "direction": {
+        "name": "dir",
+        "display_name": "Phase-Encoding Direction",
+        "description": "The `dir-<label>` entity can be set to an arbitrary alphanumeric label\n(for example, `dir-LR` or `dir-AP`)\nto distinguish different phase-encoding directions.\n\nThis entity represents the `\"PhaseEncodingDirection\"` metadata field.\nTherefore, if the `dir-<label>` entity is present in a filename,\n`\"PhaseEncodingDirection\"` MUST be defined in the associated metadata.\nPlease note that the `<label>` does not need to match the actual value of the field.\n",
+        "type": "string",
+        "format": "label"
+      },
+      "echo": {
+        "name": "echo",
+        "display_name": "Echo",
+        "description": "If files belonging to an entity-linked file collection are acquired at different\necho times, the `echo-<index>` entity MUST be used to distinguish individual files.\n\nThis entity represents the `\"EchoTime\"` metadata field.\nTherefore, if the `echo-<index>` entity is present in a filename,\n`\"EchoTime\"` MUST be defined in the associated metadata.\nPlease note that the `<index>` denotes the number/index (in the form of a nonnegative integer),\nnot the `\"EchoTime\"` value of the separate JSON file.\n",
+        "type": "string",
+        "format": "index"
+      },
+      "flip": {
+        "name": "flip",
+        "display_name": "Flip Angle",
+        "description": "If files belonging to an entity-linked file collection are acquired at different\nflip angles, the `_flip-<index>` entity pair MUST be used to distinguish\nindividual files.\n\nThis entity represents the `\"FlipAngle\"` metadata field.\nTherefore, if the `flip-<index>` entity is present in a filename,\n`\"FlipAngle\"` MUST be defined in the associated metadata.\nPlease note that the `<index>` denotes the number/index (in the form of a nonnegative integer),\nnot the `\"FlipAngle\"` value of the separate JSON file.\n",
+        "type": "string",
+        "format": "index"
+      },
+      "hemisphere": {
+        "name": "hemi",
+        "display_name": "Hemisphere",
+        "description": "The `hemi-<label>` entity indicates which hemibrain is described by the file.\nAllowed label values for this entity are `L` and `R`, for the left and right\nhemibrains, respectively.\n",
+        "type": "string",
+        "format": "label",
+        "enum": [
+          "L",
+          "R"
+        ]
+      },
+      "inversion": {
+        "name": "inv",
+        "display_name": "Inversion Time",
+        "description": "If files belonging to an entity-linked file collection are acquired at different inversion times,\nthe `inv-<index>` entity MUST be used to distinguish individual files.\n\nThis entity represents the `\"InversionTime` metadata field.\nTherefore, if the `inv-<index>` entity is present in a filename,\n`\"InversionTime\"` MUST be defined in the associated metadata.\nPlease note that the `<index>` denotes the number/index (in the form of a nonnegative integer),\nnot the `\"InversionTime\"` value of the separate JSON file.\n",
+        "type": "string",
+        "format": "index"
+      },
+      "label": {
+        "name": "label",
+        "display_name": "Label",
+        "description": "Tissue-type label, following a prescribed vocabulary.\nApplies to binary masks and probabilistic/partial volume segmentations\nthat describe a single tissue type.\n\nThis entity is only applicable to derivative data.\n",
+        "type": "string",
+        "format": "label"
+      },
+      "modality": {
+        "name": "mod",
+        "display_name": "Corresponding Modality",
+        "description": "The `mod-<label>` entity corresponds to modality label for defacing\nmasks, for example, T1w, inplaneT1, referenced by a defacemask image.\nFor example, `sub-01_mod-T1w_defacemask.nii.gz`.\n",
+        "type": "string",
+        "format": "label"
+      },
+      "mtransfer": {
+        "name": "mt",
+        "display_name": "Magnetization Transfer",
+        "description": "If files belonging to an entity-linked file collection are acquired at different\nmagnetization transfer (MT) states, the `_mt-<label>` entity MUST be used to\ndistinguish individual files.\n\nThis entity represents the `\"MTState\"` metadata field.\nTherefore, if the `mt-<label>` entity is present in a filename,\n`\"MTState\"` MUST be defined in the associated metadata.\nAllowed label values for this entity are `on` and `off`,\nfor images acquired in presence and absence of an MT pulse, respectively.\n",
+        "type": "string",
+        "format": "label",
+        "enum": [
+          "on",
+          "off"
+        ]
+      },
+      "part": {
+        "name": "part",
+        "display_name": "Part",
+        "description": "This entity is used to indicate which component of the complex\nrepresentation of the MRI signal is represented in voxel data.\nThe `part-<label>` entity is associated with the DICOM Tag\n`0008, 9208`.\nAllowed label values for this entity are `phase`, `mag`, `real` and `imag`,\nwhich are typically used in `part-mag`/`part-phase` or\n`part-real`/`part-imag` pairs of files.\n\nPhase images MAY be in radians or in arbitrary units.\nThe sidecar JSON file MUST include the units of the `phase` image.\nThe possible options are `\"rad\"` or `\"arbitrary\"`.\n\nWhen there is only a magnitude image of a given type, the `part` entity MAY be\nomitted.\n",
+        "type": "string",
+        "format": "label",
+        "enum": [
+          "mag",
+          "phase",
+          "real",
+          "imag"
+        ]
+      },
+      "processing": {
+        "name": "proc",
+        "display_name": "Processed (on device)",
+        "description": "The proc label is analogous to rec for MR and denotes a variant of\na file that was a result of particular processing performed on the device.\n\nThis is useful for files produced in particular by Elekta's MaxFilter\n(for example, `sss`, `tsss`, `trans`, `quat` or `mc`),\nwhich some installations impose to be run on raw data because of active\nshielding software corrections before the MEG data can actually be\nexploited.\n",
+        "type": "string",
+        "format": "label"
+      },
+      "reconstruction": {
+        "name": "rec",
+        "display_name": "Reconstruction",
+        "description": "The `rec-<label>` entity can be used to distinguish different reconstruction algorithms\n(for example, `MoCo` for the ones using motion correction).\n",
+        "type": "string",
+        "format": "label"
+      },
+      "recording": {
+        "name": "recording",
+        "display_name": "Recording",
+        "description": "The `recording-<label>` entity can be used to distinguish continuous recording files.\n\nThis entity is commonly applied when continuous recordings have different sampling frequencies or start times.\nFor example, physiological recordings with different sampling frequencies may be distinguished using\nlabels like `recording-100Hz` and `recording-500Hz`.\n",
+        "type": "string",
+        "format": "label"
+      },
+      "resolution": {
+        "name": "res",
+        "display_name": "Resolution",
+        "description": "Resolution of regularly sampled N-dimensional data.\n\nThis entity represents the `\"Resolution\"` metadata field.\nTherefore, if the `res-<label>` entity is present in a filename,\n`\"Resolution\"` MUST also be added in the JSON file, to provide interpretation.\n\nThis entity is only applicable to derivative data.\n",
+        "type": "string",
+        "format": "label"
+      },
+      "run": {
+        "name": "run",
+        "display_name": "Run",
+        "description": "The `run-<index>` entity is used to distinguish separate data acquisitions with the same acquisition parameters\nand (other) entities.\n\nIf several data acquisitions (for example, MRI scans or EEG recordings)\nwith the same acquisition parameters are acquired in the same session,\nthey MUST be indexed with the [`run-<index>`](SPEC_ROOT/appendices/entities.md#run) entity:\n`_run-1`, `_run-2`, `_run-3`, and so on\n(only nonnegative integers are allowed as run indices).\n\nIf different entities apply,\nsuch as a different session indicated by [`ses-<label>`][SPEC_ROOT/appendices/entities.md#ses),\nor different acquisition parameters indicated by\n[`acq-<label>`](SPEC_ROOT/appendices/entities.md#acq),\nthen `run` is not needed to distinguish the scans and MAY be omitted.\n",
+        "type": "string",
+        "format": "index"
+      },
+      "sample": {
+        "name": "sample",
+        "display_name": "Sample",
+        "description": "A sample pertaining to a subject such as tissue, primary cell or cell-free sample.\nThe `sample-<label>` entity is used to distinguish between different samples from the same subject.\nThe label MUST be unique per subject and is RECOMMENDED to be unique throughout the dataset.\n",
+        "type": "string",
+        "format": "label"
+      },
+      "session": {
+        "name": "ses",
+        "display_name": "Session",
+        "description": "A logical grouping of neuroimaging and behavioral data consistent across subjects.\nSession can (but doesn't have to) be synonymous to a visit in a longitudinal study.\nIn general, subjects will stay in the scanner during one session.\nHowever, for example, if a subject has to leave the scanner room and then\nbe re-positioned on the scanner bed, the set of MRI acquisitions will still\nbe considered as a session and match sessions acquired in other subjects.\nSimilarly, in situations where different data types are obtained over\nseveral visits (for example fMRI on one day followed by DWI the day after)\nthose can be grouped in one session.\n\nDefining multiple sessions is appropriate when several identical or similar\ndata acquisitions are planned and performed on all -or most- subjects,\noften in the case of some intervention between sessions\n(for example, training).\n",
+        "type": "string",
+        "format": "label"
+      },
+      "space": {
+        "name": "space",
+        "display_name": "Space",
+        "description": "The `space-<label>` entity can be used to indicate the way in which electrode positions are interpreted\n(for EEG/MEG/iEEG data)\nor the spatial reference to which a file has been aligned (for MRI data).\nThe `<label>` MUST be taken from one of the modality specific lists in the\n[Coordinate Systems Appendix](SPEC_ROOT/appendices/coordinate-systems.md).\nFor example, for iEEG data, the restricted keywords listed under\n[iEEG Specific Coordinate Systems](SPEC_ROOT/appendices/coordinate-systems.md#ieeg-specific-coordinate-systems)\nare acceptable for `<label>`.\n\nFor EEG/MEG/iEEG data, this entity can be applied to raw data,\nbut for other data types, it is restricted to derivative data.\n",
+        "type": "string",
+        "format": "label"
+      },
+      "split": {
+        "name": "split",
+        "display_name": "Split",
+        "description": "In the case of long data recordings that exceed a file size of 2Gb,\n`.fif` files are conventionally split into multiple parts.\nEach of these files has an internal pointer to the next file.\nThis is important when renaming these split recordings to the BIDS convention.\n\nInstead of a simple renaming, files should be read in and saved under their\nnew names with dedicated tools like [MNE-Python](https://mne.tools/),\nwhich will ensure that not only the file names, but also the internal file pointers, will be updated.\n\nIt is RECOMMENDED that `.fif` files with multiple parts use the `split-<index>` entity to indicate each part.\nIf there are multiple parts of a recording and the optional `scans.tsv` is provided,\nall files MUST be listed separately in `scans.tsv` and\nthe entries for the `acq_time` column in `scans.tsv` MUST all be identical,\nas described in [Scans file](SPEC_ROOT/03-modality-agnostic-files.md#scans-file).\n",
+        "type": "string",
+        "format": "index"
+      },
+      "stain": {
+        "name": "stain",
+        "display_name": "Stain",
+        "description": "The `stain-<label>` key/pair values can be used to distinguish image files\nfrom the same sample using different stains or antibodies for contrast enhancement.\n\nThis entity represents the `\"SampleStaining\"` metadata field.\nTherefore, if the `stain-<label>` entity is present in a filename,\n`\"SampleStaining\"` SHOULD be defined in the associated metadata,\nalthough the label may be different.\n\nDescriptions of antibodies SHOULD also be indicated in the `\"SamplePrimaryAntibodies\"`\nand/or `\"SampleSecondaryAntobodies\"` metadata fields, as appropriate.\n",
+        "type": "string",
+        "format": "label"
+      },
+      "subject": {
+        "name": "sub",
+        "display_name": "Subject",
+        "description": "A person or animal participating in the study.\n",
+        "type": "string",
+        "format": "label"
+      },
+      "task": {
+        "name": "task",
+        "display_name": "Task",
+        "description": "A set of structured activities performed by the participant.\nTasks are usually accompanied by stimuli and responses, and can greatly vary in complexity.\n\nIn the context of brain scanning, a task is always tied to one data acquisition.\nTherefore, even if during one acquisition the subject performed multiple conceptually different behaviors\n(with different sets of instructions) they will be considered one (combined) task.\n\nWhile tasks may be repeated across multiple acquisitions,\na given task may have different sets of stimuli (for example, randomized order) and participant responses\nacross subjects, sessions, and runs.\n\nThe `task-<label>` MUST be consistent across subjects and sessions.\n\nFiles with the `task-<label>` entity SHOULD have an associated\n[events file](SPEC_ROOT/04-modality-specific-files/05-task-events.md#task-events),\nas well as certain metadata fields in the associated JSON file.\n\nFor the purpose of this specification we consider the so-called \"resting state\" a task,\nalthough events files are not expected for resting state data.\nAdditionally, a common convention in the specification is to include the word \"rest\" in\nthe `task` label for resting state files (for example, `task-rest`).\n",
+        "type": "string",
+        "format": "label"
+      },
+      "tracer": {
+        "name": "trc",
+        "display_name": "Tracer",
+        "description": "The `trc-<label>` entity can be used to distinguish sequences using different tracers.\n\nThis entity represents the `\"TracerName\"` metadata field.\nTherefore, if the `trc-<label>` entity is present in a filename,\n`\"TracerName\"` MUST be defined in the associated metadata.\nPlease note that the `<label>` does not need to match the actual value of the field.\n",
+        "type": "string",
+        "format": "label"
+      }
+    },
+    "extensions": {
+      "ave": {
+        "value": ".ave",
+        "display_name": "AVE",
+        "description": "File containing data averaged by segments of interest.\n\nUsed by KIT, Yokogawa, and Ricoh MEG systems.\n"
+      },
+      "bdf": {
+        "value": ".bdf",
+        "display_name": "Biosemi Data Format",
+        "description": "A [Biosemi](https://www.biosemi.com/) Data Format file.\n\nEach recording consists of a single `.bdf` file.\n[`bdf+`](https://www.teuniz.net/edfbrowser/bdfplus%20format%20description.html) files are permitted.\nThe capital `.BDF` extension MUST NOT be used.\n"
+      },
+      "bval": {
+        "value": ".bval",
+        "display_name": "FSL-Format Gradient Amplitudes",
+        "description": "A space-delimited file containing gradient directions (b-vectors) of diffusion measurement.\n\nThe `bval` file contains the *b*-values (in s/mm<sup>2</sup>) corresponding to the\nvolumes in the relevant NIfTI file, with 0 designating *b*=0 volumes.\n"
+      },
+      "bvec": {
+        "value": ".bvec",
+        "display_name": "FSL-Format Gradient Directions",
+        "description": "A space-delimited file containing gradient directions (b-vectors) of diffusion measurement.\n\nThis file contains 3 rows with *N* space-delimited floating-point numbers,\ncorresponding to the *N* volumes in the corresponding NIfTI file.\n\nThe first row contains the *x* elements, the second row contains the *y* elements and\nthe third row contains the *z* elements of a unit vector in the direction of the applied\ndiffusion gradient, where the *i*-th elements in each row correspond together to\nthe *i*-th volume, with `[0,0,0]` for *non-diffusion-weighted* (also called *b*=0 or *low-b*)\nvolumes.\n\nFollowing the FSL format for the `bvec` specification, the coordinate system of\nthe *b* vectors MUST be defined with respect to the coordinate system defined by\nthe header of the corresponding `_dwi` NIfTI file and not the scanner's device\ncoordinate system (see [Coordinate systems](SPEC_ROOT/appendices/coordinate-systems.md)).\nThe most relevant limitation imposed by this choice is that the gradient information cannot\nbe directly stored in this format if the scanner generates *b*-vectors in *scanner coordinates*.\n"
+      },
+      "chn": {
+        "value": ".chn",
+        "display_name": "KRISS CHN",
+        "description": "A file generated by KRISS MEG systems containing the position of the center of the MEG coils.\n\nEach experimental run on the KRISS system produces a file with extension `.kdf`.\nAdditional files that may be available in the same directory include\nthe digitized positions of the head points (`\\_digitizer.txt`),\nthe position of the center of the MEG coils (`.chn`),\nand the event markers (`.trg`).\n"
+      },
+      "con": {
+        "value": ".con",
+        "display_name": "KIT/Yokogawa/Ricoh Continuous Data",
+        "description": "Raw continuous data from a KIT/Yokogawa/Ricoh MEG system.\n\nSuccessor to the `.sqd` extension for raw continuous data.\n"
+      },
+      "dat": {
+        "value": ".dat",
+        "display_name": "MEG Fine-Calibration Format",
+        "description": "A fine-calibration file used for Neuromag/Elekta/MEGIN MEG recording hardware.\n"
+      },
+      "CTF": {
+        "value": ".ds/",
+        "display_name": "CTF MEG Dataset Directory",
+        "description": "A directory for MEG data, typically containing a `.meg4` file for the data and a `.res4` file for the resources.\n"
+      },
+      "dlabelnii": {
+        "value": ".dlabel.nii",
+        "display_name": "CIFTI-2 Dense Label File",
+        "description": "A CIFTI-2 dense label file.\n\nThis extension may only be used in derivative datasets.\n"
+      },
+      "edf": {
+        "value": ".edf",
+        "display_name": "European Data Format",
+        "description": "A [European data format](https://www.edfplus.info/) file.\n\nEach recording consists of a single `.edf`` file.\n[`edf+`](https://www.edfplus.info/specs/edfplus.html) files are permitted.\nThe capital `.EDF` extension MUST NOT be used.\n"
+      },
+      "eeg": {
+        "value": ".eeg",
+        "display_name": "BrainVision Binary Data",
+        "description": "A binary data file in the\n[BrainVision Core Data Format](https://www.brainproducts.com/support-resources/brainvision-core-data-format-1-0/).\nThese files come in three-file sets, including a `.vhdr`, a `.vmrk`, and a `.eeg` file.\n"
+      },
+      "fdt": {
+        "value": ".fdt",
+        "display_name": "EEGLAB FDT",
+        "description": "An [EEGLAB](https://sccn.ucsd.edu/eeglab) file.\n\nThe format used by the MATLAB toolbox [EEGLAB](https://sccn.ucsd.edu/eeglab).\nEach recording consists of a `.set` file with an optional `.fdt` file.\n"
+      },
+      "fif": {
+        "value": ".fif",
+        "display_name": "Functional Imaging File Format",
+        "description": "An MEG file format used by Neuromag, Elekta, and MEGIN.\n"
+      },
+      "jpg": {
+        "value": ".jpg",
+        "display_name": "Joint Photographic Experts Group Format",
+        "description": "A JPEG image file.\n"
+      },
+      "json": {
+        "value": ".json",
+        "display_name": "JavaScript Object Notation",
+        "description": "A JSON file.\n\nIn the BIDS specification, JSON files are primarily used as \"sidecar\" files, in which metadata describing \"data\"\nfiles are encoded.\nThese sidecar files follow the inheritance principle.\n\nThere are also a few special cases of JSON files being first-order data files, such as `genetic_info.json`.\n"
+      },
+      "kdf": {
+        "value": ".kdf",
+        "display_name": "KRISS KDF",
+        "description": "A KRISS (file with extension `.kdf`) file.\n\nEach experimental run on the KRISS system produces a file with extension `.kdf`.\nAdditional files that may be available in the same directory include\nthe digitized positions of the head points (`\\_digitizer.txt`),\nthe position of the center of the MEG coils (`.chn`),\nand the event markers (`.trg`).\n"
+      },
+      "labelgii": {
+        "value": ".label.gii",
+        "display_name": "GIFTI label/annotation file",
+        "description": "A GIFTI label/annotation file.\n\nThis extension may only be used in derivative datasets.\n"
+      },
+      "md": {
+        "value": ".md",
+        "display_name": "Markdown",
+        "description": "A Markdown file.\n"
+      },
+      "mefd": {
+        "value": ".mefd/",
+        "display_name": "Multiscale Electrophysiology File Format Version 3.0",
+        "description": "A directory in the [MEF3](https://osf.io/e3sf9/) format.\n\nEach recording consists of a `.mefd` directory.\n"
+      },
+      "mhd": {
+        "value": ".mhd",
+        "display_name": "ITAB Binary Header",
+        "description": "Produced by ITAB-ARGOS153 systems. This file a binary header file, and is generated along with a\nraw data file with the `.raw` extension.\n"
+      },
+      "mrk": {
+        "value": ".mrk",
+        "display_name": "MRK",
+        "description": "A file containing MEG sensor coil positions.\n\nUsed by KIT, Yokogawa, and Ricoh MEG systems.\nSuccessor to the `.sqd` extension for marker files.\n"
+      },
+      "OMEZARR": {
+        "value": ".ome.zarr/",
+        "display_name": "OME Next Generation File Format",
+        "description": "An OME-NGFF file.\n\nOME-NGFF is a [Zarr](https://zarr.readthedocs.io)-based format, organizing data arrays in nested directories.\nThis format was developed by the Open Microscopy Environment to provide data stream access to very large data.\n"
+      },
+      "nii": {
+        "value": ".nii",
+        "display_name": "NIfTI",
+        "description": "A Neuroimaging Informatics Technology Initiative (NIfTI) data file.\n"
+      },
+      "niigz": {
+        "value": ".nii.gz",
+        "display_name": "Compressed NIfTI",
+        "description": "A compressed Neuroimaging Informatics Technology Initiative (NIfTI) data file.\n"
+      },
+      "nwb": {
+        "value": ".nwb",
+        "display_name": "Neurodata Without Borders Format",
+        "description": "A [Neurodata Without Borders](https://nwb-schema.readthedocs.io) file.\n\nEach recording consists of a single `.nwb` file.\n"
+      },
+      "OMEBigTiff": {
+        "value": ".ome.btf",
+        "display_name": "Open Microscopy Environment BigTIFF",
+        "description": "A [BigTIFF](https://www.awaresystems.be/imaging/tiff/bigtiff.html) image file, for very large images.\n"
+      },
+      "OMETiff": {
+        "value": ".ome.tif",
+        "display_name": "Open Microscopy Environment Tag Image File Format",
+        "description": "An [OME-TIFF](https://docs.openmicroscopy.org/ome-model/6.1.2/ome-tiff/specification.html#) image file.\n"
+      },
+      "png": {
+        "value": ".png",
+        "display_name": "Portable Network Graphics",
+        "description": "A [Portable Network Graphics](http://www.libpng.org/pub/png/) file.\n"
+      },
+      "pos": {
+        "value": ".pos",
+        "display_name": "Head Point Position",
+        "description": "File containing digitized positions of the head points.\n\nThis may be produced by a 4D neuroimaging/BTi MEG system or a CTF MEG system.\n"
+      },
+      "raw": {
+        "value": ".raw",
+        "display_name": "RAW",
+        "description": "When produced by a KIT / Yokogawa / Ricoh MEG system, this file contains trial-based evoked fields.\n\nWhen produced by an ITAB-ARGOS153 system, this file contains raw data and is generated along with\nan associated binary header file  with the `.mhd` extension.\n"
+      },
+      "rst": {
+        "value": ".rst",
+        "display_name": "reStructuredText",
+        "description": "A [reStructuredText](https://docutils.sourceforge.io/rst.html) file.\n"
+      },
+      "set": {
+        "value": ".set",
+        "display_name": "EEGLAB SET",
+        "description": "An [EEGLAB](https://sccn.ucsd.edu/eeglab) file.\n\nThe format used by the MATLAB toolbox [EEGLAB](https://sccn.ucsd.edu/eeglab).\nEach recording consists of a `.set` file with an optional `.fdt` file.\n"
+      },
+      "snirf": {
+        "value": ".snirf",
+        "display_name": "Shared Near Infrared Spectroscopy Format",
+        "description": "HDF5 file organized according to the [SNIRF specification](https://github.com/fNIRS/snirf)\n"
+      },
+      "sqd": {
+        "value": ".sqd",
+        "display_name": "SQD",
+        "description": "A file containing either raw MEG data or MEG sensor coil positions.\nWhile this extension is still valid, it has been succeeded by `.con` for raw MEG data and `.mrk` for\nmarker information.\n\nUsed by KIT, Yokogawa, and Ricoh MEG systems.\n"
+      },
+      "tif": {
+        "value": ".tif",
+        "display_name": "Tag Image File Format",
+        "description": "A [Tag Image File Format](https://en.wikipedia.org/wiki/TIFF) file.\n"
+      },
+      "trg": {
+        "value": ".trg",
+        "display_name": "KRISS TRG",
+        "description": "A file generated by KRISS MEG systems containing the event markers.\n\nEach experimental run on the KRISS system produces a file with extension `.kdf`.\nAdditional files that may be available in the same directory include\nthe digitized positions of the head points (`\\_digitizer.txt`),\nthe position of the center of the MEG coils (`.chn`),\nand the event markers (`.trg`).\n"
+      },
+      "tsv": {
+        "value": ".tsv",
+        "display_name": "Tab-Delimited",
+        "description": "A tab-delimited file.\n"
+      },
+      "tsvgz": {
+        "value": ".tsv.gz",
+        "display_name": "Compressed Tab-Delimited",
+        "description": "A gzipped tab-delimited file.\nThis file extension is only used for very large tabular data, such as physiological recordings.\nFor smaller data, the unzipped `.tsv` extension is preferred.\n"
+      },
+      "txt": {
+        "value": ".txt",
+        "display_name": "Text",
+        "description": "A free-form text file.\n\nTab-delimited files should have the `.tsv` extension rather than a `.txt` extension.\n"
+      },
+      "vhdr": {
+        "value": ".vhdr",
+        "display_name": "BrainVision Text Header",
+        "description": "A text header file in the\n[BrainVision Core Data Format](https://www.brainproducts.com/support-resources/brainvision-core-data-format-1-0/).\nThese files come in three-file sets, including a `.vhdr`, a `.vmrk`, and a `.eeg` file.\n"
+      },
+      "vmrk": {
+        "value": ".vmrk",
+        "display_name": "BrainVision Marker",
+        "description": "A text marker file in the\n[BrainVision Core Data Format](https://www.brainproducts.com/support-resources/brainvision-core-data-format-1-0/).\nThese files come in three-file sets, including a `.vhdr`, a `.vmrk`, and a `.eeg` file.\n"
+      },
+      "Any": {
+        "value": ".*",
+        "display_name": "Any Extension",
+        "description": "Any extension is allowed.\n"
+      },
+      "None": {
+        "value": "",
+        "display_name": "No extension",
+        "description": "A file with no extension.\n"
+      },
+      "Directory": {
+        "value": "/",
+        "display_name": "Directory",
+        "description": "A directory with no extension.\nCorresponds to BTi/4D data.\n"
+      }
+    },
+    "files": {
+      "CHANGES": {
+        "display_name": "Changelog",
+        "file_type": "regular",
+        "description": "Version history of the dataset (describing changes, updates and corrections) MAY be provided in\nthe form of a `CHANGES` text file.\nThis file MUST follow the\n[CPAN Changelog convention](https://metacpan.org/pod/release/HAARG/CPAN-Changes-0.400002/lib/\\\nCPAN/Changes/Spec.pod).\nThe `CHANGES` file MUST be either in ASCII or UTF-8 encoding.\n"
+      },
+      "LICENSE": {
+        "display_name": "License",
+        "file_type": "regular",
+        "description": "A `LICENSE` file MAY be provided in addition to the short specification of the\nused license in the `dataset_description.json` `\"License\"` field.\nThe `\"License\"` field and `LICENSE` file MUST correspond.\nThe `LICENSE` file MUST be either in ASCII or UTF-8 encoding.\n"
+      },
+      "README": {
+        "display_name": "README",
+        "file_type": "regular",
+        "description": "A REQUIRED text file, `README`, SHOULD describe the dataset in more detail.\nThe `README` file MUST be either in ASCII or UTF-8 encoding and MAY have one of the extensions:\n`.md` ([Markdown](https://www.markdownguide.org/)),\n`.rst` ([reStructuredText](https://docutils.sourceforge.io/rst.html)),\nor `.txt`.\nA BIDS dataset MUST NOT contain more than one `README` file (with or without extension)\nat its root directory.\nBIDS does not make any recommendations with regards to the\n[Markdown flavor](https://www.markdownguide.org/extended-syntax/#lightweight-markup-languages)\nand does not validate the syntax of Markdown and reStructuredText.\nThe `README` file SHOULD be structured such that its contents can be easily understood\neven if the used format is not rendered.\nA guideline for creating a good `README` file can be found in the\n[bids-starter-kit](https://github.com/bids-standard/bids-starter-kit/blob/master/templates/README).\n"
+      },
+      "dataset_description": {
+        "display_name": "Dataset Description",
+        "file_type": "regular",
+        "description": "The file `dataset_description.json` is a JSON file describing the dataset.\n"
+      },
+      "genetic_info": {
+        "display_name": "Genetic Information",
+        "file_type": "regular",
+        "description": "The `genetic_info.json` file describes the genetic information available in the\n`participants.tsv` file and/or the genetic database described in\n`dataset_description.json`.\nDatasets containing the `Genetics` field in `dataset_description.json` or the\n`genetic_id` column in `participants.tsv` MUST include this file.\n"
+      },
+      "participants": {
+        "display_name": "Participant Information",
+        "file_type": "regular",
+        "description": "The purpose of this RECOMMENDED file is to describe properties of participants\nsuch as age, sex, handedness.\nIf this file exists, it MUST contain the column `participant_id`,\nwhich MUST consist of `sub-<label>` values identifying one row for each participant,\nfollowed by a list of optional columns describing participants.\nEach participant MUST be described by one and only one row.\n\nCommonly used *optional* columns in `participant.tsv` files are `age`, `sex`,\nand `handedness`. We RECOMMEND to make use of these columns, and\nin case that you do use them, we RECOMMEND to use the following values\nfor them:\n\n-   `age`: numeric value in years (float or integer value)\n\n-   `sex`: string value indicating phenotypical sex, one of \"male\", \"female\",\n    \"other\"\n\n    -   for \"male\", use one of these values: `male`, `m`, `M`, `MALE`, `Male`\n\n    -   for \"female\", use one of these values: `female`, `f`, `F`, `FEMALE`,\n        `Female`\n\n    -   for \"other\", use one of these values: `other`, `o`, `O`, `OTHER`,\n        `Other`\n\n-   `handedness`: string value indicating one of \"left\", \"right\",\n    \"ambidextrous\"\n\n    -   for \"left\", use one of these values: `left`, `l`, `L`, `LEFT`, `Left`\n\n    -   for \"right\", use one of these values: `right`, `r`, `R`, `RIGHT`,\n        `Right`\n\n    -   for \"ambidextrous\", use one of these values: `ambidextrous`, `a`, `A`,\n        `AMBIDEXTROUS`, `Ambidextrous`\n\nThroughout BIDS you can indicate missing values with `n/a` (for \"not\navailable\").\n"
+      },
+      "samples": {
+        "display_name": "Sample Information",
+        "file_type": "regular",
+        "description": "The purpose of this file is to describe properties of samples, indicated by the `sample` entity.\nThis file is REQUIRED if `sample-<label>` is present in any file name within the dataset.\nIf this file exists, it MUST contain the three following columns:\n\n-   `sample_id`: MUST consist of `sample-<label>` values identifying one row\n    for each sample\n\n-   `participant_id`: MUST consist of `sub-<label>`\n\n-   `sample_type`: MUST consist of sample type values, either `cell line`, `in vitro differentiated cells`,\n    `primary cell`, `cell-free sample`, `cloning host`, `tissue`, `whole organisms`, `organoid` or\n    `technical sample` from [ENCODE Biosample Type](https://www.encodeproject.org/profiles/biosample_type)\n\nOther optional columns MAY be used to describe the samples.\nEach sample MUST be described by one and only one row.\n\nCommonly used *optional* columns in `samples.tsv` files are `pathology` and\n`derived_from`. We RECOMMEND to make use of these columns, and in case that\nyou do use them, we RECOMMEND to use the following values for them:\n\n-   `pathology`: string value describing the pathology of the sample or type of control.\n    When different from `healthy`, pathology SHOULD be specified in `samples.tsv`.\n    The pathology MAY instead be specified in\n    [Sessions files](SPEC_ROOT/03-modality-agnostic-files.md#sessions-file) in case it changes over time.\n\n-   `derived_from`: `sample-<label>` key/value pair from which a sample is derived from,\n    for example a slice of tissue (`sample-02`) derived from a block of tissue (`sample-01`)\n"
+      },
+      "code": {
+        "display_name": "Code",
+        "file_type": "directory",
+        "description": "A directory in which to store any code\n(for example the one used to generate the derivatives from the raw data).\nSee the [Code section](SPEC_ROOT/03-modality-agnostic-files.md#code)\nfor more information.\n"
+      },
+      "derivatives": {
+        "display_name": "Derivative data",
+        "file_type": "directory",
+        "description": "Derivative data (for example preprocessed files).\nSee the [relevant section](SPEC_ROOT/02-common-principles.md#source-vs-raw-vs-derived-data)\nfor more information.\n"
+      },
+      "sourcedata": {
+        "display_name": "Source data",
+        "file_type": "directory",
+        "description": "A directory where to store data before harmonization, reconstruction,\nand/or file format conversion (for example, E-Prime event logs or DICOM files).\nSee the [relevant section](SPEC_ROOT/02-common-principles.md#source-vs-raw-vs-derived-data)\nfor more information.\n"
+      },
+      "stimuli": {
+        "display_name": "Stimulus files",
+        "file_type": "directory",
+        "description": "A directory to store any stimulus files used during an experiment.\nSee the [relevant section](SPEC_ROOT/04-modality-specific-files/05-task-events.md#stimuli-directory)\nfor more information.\n"
+      }
+    },
+    "formats": {
+      "index": {
+        "display_name": "Index",
+        "description": "Non-negative, non-zero integers, optionally prefixed with leading zeros for sortability.\nAn index may not be all zeros.\n",
+        "pattern": "[0-9]*[1-9]+[0-9]*"
+      },
+      "label": {
+        "display_name": "Label",
+        "description": "Freeform labels without special characters.\n",
+        "pattern": "[0-9a-zA-Z]+"
+      },
+      "boolean": {
+        "display_name": "Boolean",
+        "description": "A boolean.\nMust be either \"true\" or \"false\".\n",
+        "pattern": "(true|false)"
+      },
+      "integer": {
+        "display_name": "Integer",
+        "description": "An integer which may be positive or negative.\n",
+        "pattern": "[+-]?\\d+"
+      },
+      "number": {
+        "display_name": "Number",
+        "description": "A number which may be an integer or float, positive or negative.\n",
+        "pattern": "[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)([eE][+-]?[0-9]+)?"
+      },
+      "string": {
+        "display_name": "String",
+        "description": "The basic string type (not a specific format).\nThis should allow any free-form string.\n",
+        "pattern": ".*"
+      },
+      "hed_version": {
+        "display_name": "HED Version",
+        "description": "The version string of the used HED schema.\n",
+        "pattern": "^(?:[a-zA-Z]+:)?(?:[a-zA-Z]+_)?(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\ (?:-(?:(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?\\ (?:\\+(?:[0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
+      },
+      "bids_uri": {
+        "display_name": "BIDS uniform resource indicator",
+        "description": "A BIDS uniform resource indicator.\n\nThe validation for this format is minimal.\nIt simply ensures that the value is a string with any characters that may appear in a valid URI,\nstarting with \"bids:\".\n",
+        "pattern": "bids:[0-9a-zA-Z/#:\\?\\_\\-\\.]+"
+      },
+      "dataset_relative": {
+        "display_name": "Path relative to the BIDS dataset directory",
+        "description": "A path to a file, relative to the dataset directory.\n\nThe validation for this format is minimal.\nIt simply ensures that the value is a string with any characters that may appear in a valid path,\nwithout starting with \"/\" (an absolute path).\n",
+        "pattern": "(?!/)[0-9a-zA-Z/\\_\\-\\.]+"
+      },
+      "date": {
+        "display_name": "Date",
+        "description": "A date in the form `\"YYYY-MM-DD[Z]\"`,\nwhere [Z] is an optional, valid timezone code.\n",
+        "pattern": "[0-9]{4}-[0-9]{2}-[0-9]{2}([A-Z]{2,4})?"
+      },
+      "datetime": {
+        "display_name": "Datetime",
+        "description": "A datetime in the form `\"YYYY-MM-DDThh:mm:ss[.000000][Z]\"`,\nwhere [.000000] is an optional subsecond resolution between 1 and 6 decimal points,\nand [Z] is an optional, valid timezone code.\n",
+        "pattern": "[0-9]{4}-[0-9]{2}-[0-9]{2}T(?:2[0-3]|[01][0-9]):[0-5][0-9]:[0-5][0-9](\\.[0-9]{1,6})?([A-Z]{2,4})?"
+      },
+      "file_relative": {
+        "display_name": "Path relative to the parent file",
+        "description": "A path to a file, relative to the file in which the field is defined.\n\nThe validation for this format is minimal.\nIt simply ensures that the value is a string with any characters that may appear in a valid path,\nwithout starting with \"/\" (an absolute path).\n",
+        "pattern": "(?!/)[0-9a-zA-Z/\\_\\-\\.]+"
+      },
+      "participant_relative": {
+        "display_name": "Path relative to the participant directory",
+        "description": "A path to a file, relative to the participant's directory in the dataset.\n\nThe validation for this format is minimal.\nIt simply ensures that the value is a string with any characters that may appear in a valid path,\nwithout starting with \"/\" (an absolute path) or \"sub/\"\n(a relative path starting with the participant directory, rather than relative to that directory).\n",
+        "pattern": "(?!/)(?!sub-)[0-9a-zA-Z/\\_\\-\\.]+"
+      },
+      "rrid": {
+        "display_name": "Research resource identifier",
+        "description": "A [research resource identifier](https://scicrunch.org/resources).\n",
+        "pattern": "RRID:.+_.+"
+      },
+      "stimuli_relative": {
+        "display_name": "Path relative to the stimuli directory",
+        "description": "A path to a stimulus file, relative to a `/stimuli` directory somewhere.\n\nThe validation for this format is minimal.\nIt simply ensures that the value is a string with any characters that may appear in a valid path,\nwithout starting with \"/\" (an absolute path) or \"stimuli/\"\n(a relative path starting with the stimuli directory, rather than relative to that directory).\n",
+        "pattern": "(?!/)(?!stimuli/)[0-9a-zA-Z/\\_\\-\\.]+"
+      },
+      "time": {
+        "display_name": "Time",
+        "description": "A time in the form `\"hh:mm:ss\"`.\n",
+        "pattern": "(?:2[0-3]|[01]?[0-9]):[0-5][0-9]:[0-5][0-9]"
+      },
+      "unit": {
+        "display_name": "A standardized unit",
+        "description": "A unit.\nSI units in CMIXF formatting are RECOMMENDED\n(see [Units](SPEC_ROOT/02-common-principles.md#units)).\n\nCurrently this matches any string.\n\nTODO: Somehow reference the actual unit options in the Units appendix.\n",
+        "pattern": ".*"
+      },
+      "uri": {
+        "display_name": "Uniform resource indicator",
+        "description": "A uniform resource indicator.\n",
+        "pattern": "(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?"
+      }
+    },
+    "metadata": {
+      "ACCELChannelCount": {
+        "name": "ACCELChannelCount",
+        "display_name": "Accelerometer channel count",
+        "description": "Number of accelerometer channels.\n",
+        "type": "integer",
+        "minimum": 0
+      },
+      "Acknowledgements": {
+        "name": "Acknowledgements",
+        "display_name": "Acknowledgements",
+        "description": "Text acknowledging contributions of individuals or institutions beyond\nthose listed in Authors or Funding.\n",
+        "type": "string"
+      },
+      "AcquisitionDuration": {
+        "name": "AcquisitionDuration",
+        "display_name": "Acquisition Duration",
+        "description": "Duration (in seconds) of volume acquisition.\nCorresponds to DICOM Tag 0018, 9073 `Acquisition Duration`.\nThis field is mutually exclusive with `\"RepetitionTime\"`.\n",
+        "type": "number",
+        "exclusiveMinimum": 0,
+        "unit": "s"
+      },
+      "AcquisitionMode": {
+        "name": "AcquisitionMode",
+        "display_name": "Acquisition Mode",
+        "description": "Type of acquisition of the PET data (for example, `\"list mode\"`).\n",
+        "type": "string"
+      },
+      "AcquisitionVoxelSize": {
+        "name": "AcquisitionVoxelSize",
+        "display_name": "Acquisition Voxel Size",
+        "description": "An array of numbers with a length of 3, in millimeters.\nThis parameter denotes the original acquisition voxel size,\nexcluding any inter-slice gaps and before any interpolation or resampling\nwithin reconstruction or image processing.\nAny point spread function effects, for example due to T2-blurring,\nthat would decrease the effective resolution are not considered here.\n",
+        "type": "array",
+        "minItems": 3,
+        "maxItems": 3,
+        "items": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "unit": "mm"
+        }
+      },
+      "Anaesthesia": {
+        "name": "Anaesthesia",
+        "display_name": "Anaesthesia",
+        "description": "Details of anaesthesia used, if any.\n",
+        "type": "string"
+      },
+      "AnalyticalApproach": {
+        "name": "AnalyticalApproach",
+        "display_name": "Analytical Approach",
+        "description": "Methodology or methodologies used to analyse the `\"GeneticLevel\"`.\nValues MUST be taken from the\n[database of Genotypes and Phenotypes\n(dbGaP)](https://www.ncbi.nlm.nih.gov/gap/advanced)\nunder /Study/Molecular Data Type (for example, SNP Genotypes (Array) or\nMethylation (CpG).\n",
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "AnatomicalLandmarkCoordinateSystem": {
+        "name": "AnatomicalLandmarkCoordinateSystem",
+        "display_name": "Anatomical Landmark Coordinate System",
+        "description": "Defines the coordinate system for the anatomical landmarks.\nSee the [Coordinate Systems Appendix](SPEC_ROOT/appendices/coordinate-systems.md)\nfor a list of restricted keywords for coordinate systems.\nIf `\"Other\"`, provide definition of the coordinate system in\n`\"AnatomicalLandmarkCoordinateSystemDescription\"`.\n",
+        "type": "string",
+        "enum": [
+          "CTF",
+          "ElektaNeuromag",
+          "4DBti",
+          "KitYokogawa",
+          "ChietiItab",
+          "Other",
+          "CapTrak",
+          "EEGLAB",
+          "EEGLAB-HJ",
+          "Other",
+          "ICBM452AirSpace",
+          "ICBM452Warp5Space",
+          "IXI549Space",
+          "fsaverage",
+          "fsaverageSym",
+          "fsLR",
+          "MNIColin27",
+          "MNI152Lin",
+          "MNI152NLin2009aSym",
+          "MNI152NLin2009bSym",
+          "MNI152NLin2009cSym",
+          "MNI152NLin2009aAsym",
+          "MNI152NLin2009bAsym",
+          "MNI152NLin2009cAsym",
+          "MNI152NLin6Sym",
+          "MNI152NLin6ASym",
+          "MNI305",
+          "NIHPD",
+          "OASIS30AntsOASISAnts",
+          "OASIS30Atropos",
+          "Talairach",
+          "UNCInfant",
+          "fsaverage3",
+          "fsaverage4",
+          "fsaverage5",
+          "fsaverage6",
+          "fsaveragesym",
+          "UNCInfant0V21",
+          "UNCInfant1V21",
+          "UNCInfant2V21",
+          "UNCInfant0V22",
+          "UNCInfant1V22",
+          "UNCInfant2V22",
+          "UNCInfant0V23",
+          "UNCInfant1V23",
+          "UNCInfant2V23"
+        ]
+      },
+      "AnatomicalLandmarkCoordinateSystemDescription": {
+        "name": "AnatomicalLandmarkCoordinateSystemDescription",
+        "display_name": "Anatomical Landmark Coordinate System Description",
+        "description": "Free-form text description of the coordinate system.\nMay also include a link to a documentation page or paper describing the\nsystem in greater detail.\n",
+        "type": "string"
+      },
+      "AnatomicalLandmarkCoordinateUnits": {
+        "name": "AnatomicalLandmarkCoordinateUnits",
+        "display_name": "Anatomical Landmark Coordinate Units",
+        "description": "Units of the coordinates of `\"AnatomicalLandmarkCoordinateSystem\"`.\n",
+        "type": "string",
+        "enum": [
+          "m",
+          "mm",
+          "cm",
+          "n/a"
+        ]
+      },
+      "AnatomicalLandmarkCoordinates": {
+        "name": "AnatomicalLandmarkCoordinates",
+        "display_name": "Anatomical Landmark Coordinates",
+        "description": "Key-value pairs of the labels and 3-D digitized locations of anatomical landmarks,\ninterpreted following the `\"AnatomicalLandmarkCoordinateSystem\"`\n(for example, `{\"NAS\": [12.7,21.3,13.9], \"LPA\": [5.2,11.3,9.6],\n\"RPA\": [20.2,11.3,9.1]}`.\nEach array MUST contain three numeric values corresponding to x, y, and z\naxis of the coordinate system in that exact order.\n",
+        "type": "object",
+        "additionalProperties": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 3,
+          "maxItems": 3
+        }
+      },
+      "AnatomicalLandmarkCoordinates__mri": {
+        "name": "AnatomicalLandmarkCoordinates",
+        "display_name": "Anatomical Landmark Coordinates",
+        "description": "Key-value pairs of any number of additional anatomical landmarks and their\ncoordinates in voxel units (where first voxel has index 0,0,0)\nrelative to the associated anatomical MRI\n(for example, `{\"AC\": [127,119,149], \"PC\": [128,93,141],\n\"IH\": [131,114,206]}`, or `{\"NAS\": [127,213,139], \"LPA\": [52,113,96],\n\"RPA\": [202,113,91]}`).\nEach array MUST contain three numeric values corresponding to x, y, and z\naxis of the coordinate system in that exact order.\n",
+        "type": "object",
+        "additionalProperties": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 3,
+          "maxItems": 3
+        }
+      },
+      "ArterialSpinLabelingType": {
+        "name": "ArterialSpinLabelingType",
+        "display_name": "Arterial Spin Labeling Type",
+        "description": "The arterial spin labeling type.\n",
+        "type": "string",
+        "enum": [
+          "CASL",
+          "PCASL",
+          "PASL"
+        ]
+      },
+      "AssociatedEmptyRoom": {
+        "name": "AssociatedEmptyRoom",
+        "display_name": "Associated Empty Room",
+        "description": "One or more [BIDS URIs](SPEC_ROOT/02-common-principles.md#bids-uri)\npointing to empty-room file(s) associated with the subject's MEG recording.\nUsing forward-slash separated paths relative to the dataset root is\n[DEPRECATED](SPEC_ROOT/02-common-principles.md#definitions).\n",
+        "anyOf": [
+          {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "dataset_relative"
+                },
+                {
+                  "type": "string",
+                  "format": "bids_uri"
+                }
+              ]
+            }
+          },
+          {
+            "type": "string",
+            "format": "dataset_relative"
+          },
+          {
+            "type": "string",
+            "format": "bids_uri"
+          }
+        ]
+      },
+      "Atlas": {
+        "name": "Atlas",
+        "display_name": "Atlas",
+        "description": "Which atlas (if any) was used to generate the mask.\n",
+        "type": "string"
+      },
+      "AttenuationCorrection": {
+        "name": "AttenuationCorrection",
+        "display_name": "Attenuation Correction",
+        "description": "Short description of the attenuation correction method used.\n",
+        "type": "string"
+      },
+      "AttenuationCorrectionMethodReference": {
+        "name": "AttenuationCorrectionMethodReference",
+        "display_name": "Attenuation Correction Method Reference",
+        "description": "Reference paper for the attenuation correction method used.\n",
+        "type": "string"
+      },
+      "Authors": {
+        "name": "Authors",
+        "display_name": "Authors",
+        "description": "List of individuals who contributed to the creation/curation of the dataset.\n",
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "B0FieldIdentifier": {
+        "name": "B0FieldIdentifier",
+        "display_name": "B0 Field Identifier",
+        "description": "The presence of this key states that this particular 3D or 4D image MAY be\nused for fieldmap estimation purposes.\nEach `\"B0FieldIdentifier\"` MUST be a unique string within one participant's tree,\nshared only by the images meant to be used as inputs for the estimation of a\nparticular instance of the *B<sub>0</sub> field* estimation.\nIt is RECOMMENDED to derive this identifier from DICOM Tags, for example,\nDICOM tag 0018, 1030 `Protocol Name`, or DICOM tag 0018, 0024 `Sequence Name`\nwhen the former is not defined (for example, in GE devices.)\n",
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "B0FieldSource": {
+        "name": "B0FieldSource",
+        "display_name": "B0 Field Source",
+        "description": "At least one existing `\"B0FieldIdentifier\"` defined by images in the\nparticipant's tree.\nThis field states the *B<sub>0</sub> field* estimation designated by the\n`\"B0FieldIdentifier\"` that may be used to correct the dataset for distortions\ncaused by B<sub>0</sub> inhomogeneities.\n`\"B0FieldSource\"` and `\"B0FieldIdentifier\"` MAY both be present for images that\nare used to estimate their own B<sub>0</sub> field, for example, in \"pepolar\"\nacquisitions.\n",
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "BIDSVersion": {
+        "name": "BIDSVersion",
+        "display_name": "BIDS Version",
+        "description": "The version of the BIDS standard that was used.\n",
+        "type": "string"
+      },
+      "BackgroundSuppression": {
+        "name": "BackgroundSuppression",
+        "display_name": "Background Suppression",
+        "description": "Boolean indicating if background suppression is used.\n",
+        "type": "boolean"
+      },
+      "BackgroundSuppressionNumberPulses": {
+        "name": "BackgroundSuppressionNumberPulses",
+        "display_name": "Background Suppression Number Pulses",
+        "description": "The number of background suppression pulses used.\nNote that this excludes any effect of background suppression pulses applied\nbefore the labeling.\n",
+        "type": "number",
+        "minimum": 0
+      },
+      "BackgroundSuppressionPulseTime": {
+        "name": "BackgroundSuppressionPulseTime",
+        "display_name": "Background Suppression Pulse Time",
+        "description": "Array of numbers containing timing, in seconds,\nof the background suppression pulses with respect to the start of the\nlabeling.\nIn case of multi-PLD with different background suppression pulse times,\nonly the pulse time of the first PLD should be defined.\n",
+        "type": "array",
+        "items": {
+          "type": "number",
+          "minimum": 0,
+          "unit": "s"
+        }
+      },
+      "BasedOn": {
+        "name": "BasedOn",
+        "display_name": "Based On",
+        "description": "List of files in a file collection to generate the map.\nFieldmaps are also listed, if involved in the processing.\nThis field is DEPRECATED, and this metadata SHOULD be recorded in the\n`Sources` field using [BIDS URIs](SPEC_ROOT/02-common-principles.md#bids-uri)\nto distinguish sources from different datasets.\n",
+        "anyOf": [
+          {
+            "type": "string",
+            "format": "participant_relative"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "participant_relative"
+            }
+          }
+        ]
+      },
+      "BloodDensity": {
+        "name": "BloodDensity",
+        "display_name": "Blood Density",
+        "description": "Measured blood density. Unit of blood density should be in `\"g/mL\"`.\n",
+        "type": "number",
+        "unit": "g/mL"
+      },
+      "BodyPart": {
+        "name": "BodyPart",
+        "display_name": "Body Part",
+        "description": "Body part of the organ / body region scanned.\n",
+        "type": "string"
+      },
+      "BodyPartDetails": {
+        "name": "BodyPartDetails",
+        "display_name": "Body Part Details",
+        "description": "Additional details about body part or location (for example: `\"corpus callosum\"`).\n",
+        "type": "string"
+      },
+      "BodyPartDetailsOntology": {
+        "name": "BodyPartDetailsOntology",
+        "display_name": "Body Part Details Ontology",
+        "description": "[URI](SPEC_ROOT/02-common-principles.md#uniform-resource-indicator) of ontology used for\nBodyPartDetails (for example: `\"https://www.ebi.ac.uk/ols/ontologies/uberon\"`).\n",
+        "type": "string",
+        "format": "uri"
+      },
+      "BolusCutOffDelayTime": {
+        "name": "BolusCutOffDelayTime",
+        "display_name": "Bolus Cut Off Delay Time",
+        "description": "Duration between the end of the labeling and the start of the bolus cut-off\nsaturation pulse(s), in seconds.\nThis can be a number or array of numbers, of which the values must be\nnon-negative and monotonically increasing, depending on the number of bolus\ncut-off saturation pulses.\nFor Q2TIPS, only the values for the first and last bolus cut-off saturation\npulses are provided.\nBased on DICOM Tag 0018, 925F `ASL Bolus Cut-off Delay Time`.\n",
+        "anyOf": [
+          {
+            "type": "number",
+            "minimum": 0,
+            "unit": "s"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "unit": "s",
+              "minimum": 0
+            }
+          }
+        ]
+      },
+      "BolusCutOffFlag": {
+        "name": "BolusCutOffFlag",
+        "display_name": "Bolus Cut Off Flag",
+        "description": "Boolean indicating if a bolus cut-off technique is used.\nCorresponds to DICOM Tag 0018, 925C `ASL Bolus Cut-off Flag`.\n",
+        "type": "boolean"
+      },
+      "BolusCutOffTechnique": {
+        "name": "BolusCutOffTechnique",
+        "display_name": "Bolus Cut Off Technique",
+        "description": "Name of the technique used, for example `\"Q2TIPS\"`, `\"QUIPSS\"`, `\"QUIPSSII\"`.\nCorresponds to DICOM Tag 0018, 925E `ASL Bolus Cut-off Technique`.\n",
+        "type": "string"
+      },
+      "BrainLocation": {
+        "name": "BrainLocation",
+        "display_name": "Brain Location",
+        "description": "Refers to the location in space of the `\"TissueOrigin\"`.\nValues may be an MNI coordinate,\na label taken from the\n[Allen Brain Atlas](https://atlas.brain-map.org/atlas?atlas=265297125&plate=\\\n112360888&structure=4392&x=40348.15104166667&y=46928.75&zoom=-7&resolution=\\\n206.60&z=3),\nor layer to refer to layer-specific gene expression,\nwhich can also tie up with laminar fMRI.\n",
+        "type": "string"
+      },
+      "CASLType": {
+        "name": "CASLType",
+        "display_name": "CASL Type",
+        "description": "Describes if a separate coil is used for labeling.\n",
+        "type": "string",
+        "enum": [
+          "single-coil",
+          "double-coil"
+        ]
+      },
+      "CapManufacturer": {
+        "name": "CapManufacturer",
+        "display_name": "Cap Manufacturer",
+        "description": "Name of the cap manufacturer (for example, `\"EasyCap\"`).\n",
+        "type": "string"
+      },
+      "CapManufacturersModelName": {
+        "name": "CapManufacturersModelName",
+        "display_name": "Cap Manufacturers Model Name",
+        "description": "Manufacturer's designation of the cap model\n(for example, `\"actiCAP 64 Ch Standard-2\"`).\n",
+        "type": "string"
+      },
+      "CellType": {
+        "name": "CellType",
+        "display_name": "Cell Type",
+        "description": "Describes the type of cell analyzed.\nValues SHOULD come from the\n[cell ontology](http://obofoundry.org/ontology/cl.html).\n",
+        "type": "string"
+      },
+      "ChunkTransformationMatrix": {
+        "name": "ChunkTransformationMatrix",
+        "display_name": "Chunk Transformation Matrix",
+        "description": "3x3 or 4x4 affine transformation matrix describing spatial chunk transformation,\nfor 2D and 3D respectively (for examples: `[[2, 0, 0], [0, 3, 0], [0, 0, 1]]`\nin 2D for 2x and 3x scaling along the first and second axis respectively; or\n`[[1, 0, 0, 0], [0, 2, 0, 0], [0, 0, 3, 0], [0, 0, 0, 1]]` in 3D for 2x and 3x\nscaling along the second and third axis respectively).\nNote that non-spatial dimensions like time and channel are not included in the\ntransformation matrix.\n",
+        "anyOf": [
+          {
+            "type": "array",
+            "minItems": 3,
+            "maxItems": 3,
+            "items": {
+              "type": "array",
+              "minItems": 3,
+              "maxItems": 3,
+              "items": {
+                "type": "number"
+              }
+            }
+          },
+          {
+            "type": "array",
+            "minItems": 4,
+            "maxItems": 4,
+            "items": {
+              "type": "array",
+              "minItems": 4,
+              "maxItems": 4,
+              "items": {
+                "type": "number"
+              }
+            }
+          }
+        ]
+      },
+      "ChunkTransformationMatrixAxis": {
+        "name": "ChunkTransformationMatrixAxis",
+        "display_name": "Chunk Transformation Matrix Axis",
+        "description": "Describe the axis of the ChunkTransformationMatrix\n(for examples: `[\"X\", \"Y\"]` or `[\"Z\", \"Y\", \"X\"]`).\n",
+        "type": "array",
+        "minItems": 2,
+        "maxItems": 3,
+        "items": {
+          "type": "string"
+        }
+      },
+      "Code": {
+        "name": "Code",
+        "display_name": "Code",
+        "description": "[URI](SPEC_ROOT/02-common-principles.md#uniform-resource-indicator)\nof the code used to present the stimuli.\nPersistent identifiers such as DOIs are preferred.\nIf multiple versions of code may be hosted at the same location,\nrevision-specific URIs are recommended.\n",
+        "type": "string",
+        "format": "uri"
+      },
+      "CogAtlasID": {
+        "name": "CogAtlasID",
+        "display_name": "Cognitive Atlas ID",
+        "description": "[URI](SPEC_ROOT/02-common-principles.md#uniform-resource-indicator)\nof the corresponding [Cognitive Atlas](https://www.cognitiveatlas.org/)\nTask term.\n",
+        "type": "string",
+        "format": "uri"
+      },
+      "CogPOID": {
+        "name": "CogPOID",
+        "display_name": "Cognitive Paradigm Ontology ID",
+        "description": "[URI](SPEC_ROOT/02-common-principles.md#uniform-resource-indicator)\nof the corresponding [CogPO](http://www.cogpo.org/) term.\n",
+        "type": "string",
+        "format": "uri"
+      },
+      "CoilCombinationMethod": {
+        "name": "CoilCombinationMethod",
+        "display_name": "Coil Combination Method",
+        "description": "Almost all fMRI studies using phased-array coils use root-sum-of-squares\n(rSOS) combination, but other methods exist.\nThe image reconstruction is changed by the coil combination method\n(as for the matrix coil mode above),\nso anything non-standard should be reported.\n",
+        "type": "string"
+      },
+      "Columns": {
+        "name": "Columns",
+        "display_name": "Columns",
+        "description": "Names of columns in file.\n",
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "ContinuousHeadLocalization": {
+        "name": "ContinuousHeadLocalization",
+        "display_name": "Continuous Head Localization",
+        "description": "`true` or `false` value indicating whether continuous head localisation\nwas performed.\n",
+        "type": "boolean"
+      },
+      "ContrastBolusIngredient": {
+        "name": "ContrastBolusIngredient",
+        "display_name": "Contrast Bolus Ingredient",
+        "description": "Active ingredient of agent.\nCorresponds to DICOM Tag 0018, 1048 `Contrast/Bolus Ingredient`.\n",
+        "type": "string",
+        "enum": [
+          "IODINE",
+          "GADOLINIUM",
+          "CARBON DIOXIDE",
+          "BARIUM",
+          "XENON"
+        ]
+      },
+      "DCOffsetCorrection": {
+        "name": "DCOffsetCorrection",
+        "display_name": "DC Offset Correction",
+        "description": "A description of the method (if any) used to correct for a DC offset.\nIf the method used was subtracting the mean value for each channel,\nuse \"mean\".\n",
+        "type": "string"
+      },
+      "DatasetDOI": {
+        "name": "DatasetDOI",
+        "display_name": "DatasetDOI",
+        "description": "The Digital Object Identifier of the dataset (not the corresponding paper).\nDOIs SHOULD be expressed as a valid\n[URI](SPEC_ROOT/02-common-principles.md#uniform-resource-indicator);\nbare DOIs such as `10.0.2.3/dfjj.10` are\n[DEPRECATED](SPEC_ROOT/02-common-principles.md#definitions).\n",
+        "type": "string",
+        "format": "uri"
+      },
+      "DatasetLinks": {
+        "name": "DatasetLinks",
+        "display_name": "Dataset Links",
+        "description": "Used to map a given `<dataset-name>` from a [BIDS URI](SPEC_ROOT/02-common-principles.md#bids-uri)\nof the form `bids:<dataset-name>:path/within/dataset` to a local or remote location.\nThe `<dataset-name>`: `\"\"` (an empty string) is a reserved keyword that MUST NOT be a key in\n`DatasetLinks` (example: `bids::path/within/dataset`).\n",
+        "type": "object",
+        "additionalProperties": {
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "DatasetType": {
+        "name": "DatasetType",
+        "display_name": "Dataset Type",
+        "description": "The interpretation of the dataset.\nFor backwards compatibility, the default value is `\"raw\"`.\n",
+        "type": "string",
+        "enum": [
+          "raw",
+          "derivative"
+        ]
+      },
+      "DecayCorrectionFactor": {
+        "name": "DecayCorrectionFactor",
+        "display_name": "Decay Correction Factor",
+        "description": "Decay correction factor for each frame.\n",
+        "type": "array",
+        "items": {
+          "type": "number"
+        }
+      },
+      "DelayAfterTrigger": {
+        "name": "DelayAfterTrigger",
+        "display_name": "Delay After Trigger",
+        "description": "Duration (in seconds) from trigger delivery to scan onset.\nThis delay is commonly caused by adjustments and loading times.\nThis specification is entirely independent of\n`\"NumberOfVolumesDiscardedByScanner\"` or `\"NumberOfVolumesDiscardedByUser\"`,\nas the delay precedes the acquisition.\n",
+        "type": "number",
+        "unit": "s"
+      },
+      "DelayTime": {
+        "name": "DelayTime",
+        "display_name": "Delay Time",
+        "description": "User specified time (in seconds) to delay the acquisition of data for the\nfollowing volume.\nIf the field is not present it is assumed to be set to zero.\nCorresponds to Siemens CSA header field `lDelayTimeInTR`.\nThis field is REQUIRED for sparse sequences using the `\"RepetitionTime\"` field\nthat do not have the `\"SliceTiming\"` field set to allowed for accurate\ncalculation of \"acquisition time\".\nThis field is mutually exclusive with `\"VolumeTiming\"`.\n",
+        "type": "number",
+        "unit": "s"
+      },
+      "Density": {
+        "name": "Density",
+        "display_name": "Density",
+        "description": "Specifies the interpretation of the density keyword.\nIf an object is used, then the keys should be values for the `den` entity\nand values should be descriptions of those `den` values.\n",
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "Derivative": {
+        "name": "Derivative",
+        "display_name": "Derivative",
+        "description": "Indicates that values in the corresponding column are transformations of values\nfrom other columns (for example a summary score based on a subset of items in a\nquestionnaire).\n",
+        "type": "boolean"
+      },
+      "Description": {
+        "name": "Description",
+        "display_name": "Description",
+        "description": "Free-form natural language description.\n",
+        "type": "string"
+      },
+      "DetectorType": {
+        "name": "DetectorType",
+        "display_name": "Detector Type",
+        "description": "Type of detector. This is a free form description with the following suggested terms:\n`\"SiPD\"`, `\"APD\"`. Preferably a specific model/part number is supplied.\nIf individual channels have different `DetectorType`,\nthen the field here should be specified as `\"mixed\"`\nand this column should be included in `optodes.tsv`.\n",
+        "anyOf": [
+          {
+            "type": "string",
+            "format": "unit"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "mixed"
+            ]
+          }
+        ]
+      },
+      "DeviceSerialNumber": {
+        "name": "DeviceSerialNumber",
+        "display_name": "Device Serial Number",
+        "description": "The serial number of the equipment that produced the measurements.\nA pseudonym can also be used to prevent the equipment from being\nidentifiable, so long as each pseudonym is unique within the dataset.\n",
+        "type": "string"
+      },
+      "DewarPosition": {
+        "name": "DewarPosition",
+        "display_name": "Dewar Position",
+        "description": "Position of the dewar during the MEG scan:\n`\"upright\"`, `\"supine\"` or `\"degrees\"` of angle from vertical:\nfor example on CTF systems, `\"upright=15\u00b0, supine=90\u00b0\"`.\n",
+        "type": "string"
+      },
+      "DigitizedHeadPoints": {
+        "name": "DigitizedHeadPoints",
+        "display_name": "Digitized Head Points",
+        "description": "`true` or `false` value indicating whether head points outlining the\nscalp/face surface are contained within this recording.\n",
+        "type": "boolean"
+      },
+      "DigitizedHeadPoints__coordsystem": {
+        "name": "DigitizedHeadPoints",
+        "display_name": "Digitized Head Points",
+        "description": "Relative path to the file containing the locations of digitized head points\ncollected during the session (for example, `\"sub-01_headshape.pos\"`).\nRECOMMENDED for all MEG systems, especially for CTF and BTi/4D.\nFor Elekta/Neuromag the head points will be stored in the fif file.\n",
+        "type": "string",
+        "format": "file_relative"
+      },
+      "DigitizedHeadPointsCoordinateSystem": {
+        "name": "DigitizedHeadPointsCoordinateSystem",
+        "display_name": "Digitized Head Points Coordinate System",
+        "description": "Defines the coordinate system for the digitized head points.\nSee the\n[Coordinate Systems Appendix](SPEC_ROOT/appendices/coordinate-systems.md)\nfor a list of restricted keywords for coordinate systems.\nIf `\"Other\"`, provide definition of the coordinate system in\n`\"DigitizedHeadPointsCoordinateSystemDescription\"`.\n",
+        "type": "string",
+        "enum": [
+          "CTF",
+          "ElektaNeuromag",
+          "4DBti",
+          "KitYokogawa",
+          "ChietiItab",
+          "Other",
+          "CapTrak",
+          "EEGLAB",
+          "EEGLAB-HJ",
+          "Other",
+          "ICBM452AirSpace",
+          "ICBM452Warp5Space",
+          "IXI549Space",
+          "fsaverage",
+          "fsaverageSym",
+          "fsLR",
+          "MNIColin27",
+          "MNI152Lin",
+          "MNI152NLin2009aSym",
+          "MNI152NLin2009bSym",
+          "MNI152NLin2009cSym",
+          "MNI152NLin2009aAsym",
+          "MNI152NLin2009bAsym",
+          "MNI152NLin2009cAsym",
+          "MNI152NLin6Sym",
+          "MNI152NLin6ASym",
+          "MNI305",
+          "NIHPD",
+          "OASIS30AntsOASISAnts",
+          "OASIS30Atropos",
+          "Talairach",
+          "UNCInfant",
+          "fsaverage3",
+          "fsaverage4",
+          "fsaverage5",
+          "fsaverage6",
+          "fsaveragesym",
+          "UNCInfant0V21",
+          "UNCInfant1V21",
+          "UNCInfant2V21",
+          "UNCInfant0V22",
+          "UNCInfant1V22",
+          "UNCInfant2V22",
+          "UNCInfant0V23",
+          "UNCInfant1V23",
+          "UNCInfant2V23"
+        ]
+      },
+      "DigitizedHeadPointsCoordinateSystemDescription": {
+        "name": "DigitizedHeadPointsCoordinateSystemDescription",
+        "display_name": "Digitized Head Points Coordinate System Description",
+        "description": "Free-form text description of the coordinate system.\nMay also include a link to a documentation page or paper describing the\nsystem in greater detail.\n",
+        "type": "string"
+      },
+      "DigitizedHeadPointsCoordinateUnits": {
+        "name": "DigitizedHeadPointsCoordinateUnits",
+        "display_name": "Digitized Head Points Coordinate Units",
+        "description": "Units of the coordinates of `\"DigitizedHeadPointsCoordinateSystem\"`.\n",
+        "type": "string",
+        "enum": [
+          "m",
+          "mm",
+          "cm",
+          "n/a"
+        ]
+      },
+      "DigitizedLandmarks": {
+        "name": "DigitizedLandmarks",
+        "display_name": "Digitized Landmarks",
+        "description": "`true` or `false` value indicating whether anatomical landmark points\n(fiducials) are contained within this recording.\n",
+        "type": "boolean"
+      },
+      "DispersionConstant": {
+        "name": "DispersionConstant",
+        "display_name": "Dispersion Constant",
+        "description": "External dispersion time constant resulting from tubing in default unit\nseconds.\n",
+        "type": "number",
+        "unit": "s"
+      },
+      "DispersionCorrected": {
+        "name": "DispersionCorrected",
+        "display_name": "Dispersion Corrected",
+        "description": "Boolean flag specifying whether the blood data have been dispersion-corrected.\nNOTE: not customary for manual samples, and hence should be set to `false`.\n",
+        "type": "boolean"
+      },
+      "DoseCalibrationFactor": {
+        "name": "DoseCalibrationFactor",
+        "display_name": "Dose Calibration Factor",
+        "description": "Multiplication factor used to transform raw data (in counts/sec) to meaningful unit (Bq/ml).\nCorresponds to DICOM Tag 0054, 1322 `Dose Calibration Factor`.\n",
+        "type": "number"
+      },
+      "DwellTime": {
+        "name": "DwellTime",
+        "display_name": "Dwell Time",
+        "description": "Actual dwell time (in seconds) of the receiver per point in the readout\ndirection, including any oversampling.\nFor Siemens, this corresponds to DICOM field 0019, 1018 (in ns).\nThis value is necessary for the optional readout distortion correction of\nanatomicals in the HCP Pipelines.\nIt also usefully provides a handle on the readout bandwidth,\nwhich isn't captured in the other metadata tags.\nNot to be confused with `\"EffectiveEchoSpacing\"`, and the frequent mislabeling\nof echo spacing (which is spacing in the phase encoding direction) as\n\"dwell time\" (which is spacing in the readout direction).\n",
+        "type": "number",
+        "unit": "s"
+      },
+      "ECGChannelCount": {
+        "name": "ECGChannelCount",
+        "display_name": "ECG Channel Count",
+        "description": "Number of ECG channels.\n",
+        "type": "integer",
+        "minimum": 0
+      },
+      "ECOGChannelCount": {
+        "name": "ECOGChannelCount",
+        "display_name": "ECOG Channel Count",
+        "description": "Number of ECoG channels.\n",
+        "type": "integer",
+        "minimum": 0
+      },
+      "EEGChannelCount": {
+        "name": "EEGChannelCount",
+        "display_name": "EEG Channel Count",
+        "description": "Number of EEG channels recorded simultaneously (for example, `21`).\n",
+        "type": "integer",
+        "minimum": 0
+      },
+      "EEGCoordinateSystem": {
+        "name": "EEGCoordinateSystem",
+        "display_name": "EEG Coordinate System",
+        "description": "Defines the coordinate system for the EEG sensors.\n\nSee the\n[Coordinate Systems Appendix](SPEC_ROOT/appendices/coordinate-systems.md)\nfor a list of restricted keywords for coordinate systems.\nIf `\"Other\"`, provide definition of the coordinate system in\n`EEGCoordinateSystemDescription`.\n",
+        "type": "string",
+        "enum": [
+          "CTF",
+          "ElektaNeuromag",
+          "4DBti",
+          "KitYokogawa",
+          "ChietiItab",
+          "Other",
+          "CapTrak",
+          "EEGLAB",
+          "EEGLAB-HJ",
+          "Other",
+          "ICBM452AirSpace",
+          "ICBM452Warp5Space",
+          "IXI549Space",
+          "fsaverage",
+          "fsaverageSym",
+          "fsLR",
+          "MNIColin27",
+          "MNI152Lin",
+          "MNI152NLin2009aSym",
+          "MNI152NLin2009bSym",
+          "MNI152NLin2009cSym",
+          "MNI152NLin2009aAsym",
+          "MNI152NLin2009bAsym",
+          "MNI152NLin2009cAsym",
+          "MNI152NLin6Sym",
+          "MNI152NLin6ASym",
+          "MNI305",
+          "NIHPD",
+          "OASIS30AntsOASISAnts",
+          "OASIS30Atropos",
+          "Talairach",
+          "UNCInfant",
+          "fsaverage3",
+          "fsaverage4",
+          "fsaverage5",
+          "fsaverage6",
+          "fsaveragesym",
+          "UNCInfant0V21",
+          "UNCInfant1V21",
+          "UNCInfant2V21",
+          "UNCInfant0V22",
+          "UNCInfant1V22",
+          "UNCInfant2V22",
+          "UNCInfant0V23",
+          "UNCInfant1V23",
+          "UNCInfant2V23"
+        ]
+      },
+      "EEGCoordinateSystemDescription": {
+        "name": "EEGCoordinateSystemDescription",
+        "display_name": "EEG Coordinate System Description",
+        "description": "Free-form text description of the coordinate system.\nMay also include a link to a documentation page or paper describing the\nsystem in greater detail.\n",
+        "type": "string"
+      },
+      "EEGCoordinateUnits": {
+        "name": "EEGCoordinateUnits",
+        "display_name": "EEG Coordinate Units",
+        "description": "Units of the coordinates of `EEGCoordinateSystem`.\n",
+        "type": "string",
+        "enum": [
+          "m",
+          "mm",
+          "cm",
+          "n/a"
+        ]
+      },
+      "EEGGround": {
+        "name": "EEGGround",
+        "display_name": "EEG Ground",
+        "description": "Description of the location of the ground electrode\n(for example, `\"placed on right mastoid (M2)\"`).\n",
+        "type": "string"
+      },
+      "EEGPlacementScheme": {
+        "name": "EEGPlacementScheme",
+        "display_name": "EEG Placement Scheme",
+        "description": "Placement scheme of EEG electrodes.\nEither the name of a standardized placement system (for example, `\"10-20\"`)\nor a list of standardized electrode names (for example, `[\"Cz\", \"Pz\"]`).\n",
+        "type": "string"
+      },
+      "EEGReference": {
+        "name": "EEGReference",
+        "display_name": "EEG Reference",
+        "description": "General description of the reference scheme used and (when applicable) of\nlocation of the reference electrode in the raw recordings\n(for example, `\"left mastoid\"`, `\"Cz\"`, `\"CMS\"`).\nIf different channels have a different reference,\nthis field should have a general description and the channel specific\nreference should be defined in the `channels.tsv` file.\n",
+        "type": "string"
+      },
+      "EMGChannelCount": {
+        "name": "EMGChannelCount",
+        "display_name": "EMG Channel Count",
+        "description": "Number of EMG channels.\n",
+        "type": "integer",
+        "minimum": 0
+      },
+      "EOGChannelCount": {
+        "name": "EOGChannelCount",
+        "display_name": "EOG Channel Count",
+        "description": "Number of EOG channels.\n",
+        "type": "integer",
+        "minimum": 0
+      },
+      "EchoTime": {
+        "name": "EchoTime",
+        "display_name": "Echo Time",
+        "description": "The echo time (TE) for the acquisition, specified in seconds.\nCorresponds to DICOM Tag 0018, 0081 `Echo Time`\n(please note that the DICOM term is in milliseconds not seconds).\nThe data type number may apply to files from any MRI modality concerned with\na single value for this field, or to the files in a\n[file collection](SPEC_ROOT/appendices/file-collections.md)\nwhere the value of this field is iterated using the\n[`echo` entity](SPEC_ROOT/appendices/entities.md#echo).\nThe data type array provides a value for each volume in a 4D dataset and\nshould only be used when the volume timing is critical for interpretation\nof the data, such as in\n[ASL](SPEC_ROOT/04-modality-specific-files/01-magnetic-resonance-imaging-data.md#\\\narterial-spin-labeling-perfusion-data)\nor variable echo time fMRI sequences.\n",
+        "anyOf": [
+          {
+            "type": "number",
+            "unit": "s",
+            "exclusiveMinimum": 0
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "unit": "s",
+              "exclusiveMinimum": 0
+            }
+          }
+        ]
+      },
+      "EchoTime1": {
+        "name": "EchoTime1",
+        "display_name": "Echo Time1",
+        "description": "The time (in seconds) when the first (shorter) echo occurs.\n",
+        "type": "number",
+        "unit": "s",
+        "exclusiveMinimum": 0
+      },
+      "EchoTime2": {
+        "name": "EchoTime2",
+        "display_name": "Echo Time2",
+        "description": "The time (in seconds) when the second (longer) echo occurs.\n",
+        "type": "number",
+        "unit": "s",
+        "exclusiveMinimum": 0
+      },
+      "EchoTime__fmap": {
+        "name": "EchoTime",
+        "display_name": "Echo Time",
+        "description": "The time (in seconds) when the echo corresponding to this map was acquired.\n",
+        "type": "number",
+        "unit": "s",
+        "exclusiveMinimum": 0
+      },
+      "EffectiveEchoSpacing": {
+        "name": "EffectiveEchoSpacing",
+        "display_name": "Effective Echo Spacing",
+        "description": "The \"effective\" sampling interval, specified in seconds,\nbetween lines in the phase-encoding direction,\ndefined based on the size of the reconstructed image in the phase direction.\nIt is frequently, but incorrectly, referred to as \"dwell time\"\n(see the `\"DwellTime\"` parameter for actual dwell time).\nIt is required for unwarping distortions using field maps.\nNote that beyond just in-plane acceleration,\na variety of other manipulations to the phase encoding need to be accounted\nfor properly, including partial fourier, phase oversampling,\nphase resolution, phase field-of-view and interpolation.\n",
+        "type": "number",
+        "exclusiveMinimum": 0,
+        "unit": "s"
+      },
+      "ElectricalStimulation": {
+        "name": "ElectricalStimulation",
+        "display_name": "Electrical Stimulation",
+        "description": "Boolean field to specify if electrical stimulation was done during the\nrecording (options are `true` or `false`). Parameters for event-like\nstimulation should be specified in the `events.tsv` file.\n",
+        "type": "boolean"
+      },
+      "ElectricalStimulationParameters": {
+        "name": "ElectricalStimulationParameters",
+        "display_name": "Electrical Stimulation Parameters",
+        "description": "Free form description of stimulation parameters, such as frequency or shape.\nSpecific onsets can be specified in the events.tsv file.\nSpecific shapes can be described here in freeform text.\n",
+        "type": "string"
+      },
+      "ElectrodeManufacturer": {
+        "name": "ElectrodeManufacturer",
+        "display_name": "Electrode Manufacturer",
+        "description": "Can be used if all electrodes are of the same manufacturer\n(for example, `\"AD-TECH\"`, `\"DIXI\"`).\nIf electrodes of different manufacturers are used,\nplease use the corresponding table in the `_electrodes.tsv` file.\n",
+        "type": "string"
+      },
+      "ElectrodeManufacturersModelName": {
+        "name": "ElectrodeManufacturersModelName",
+        "display_name": "Electrode Manufacturers Model Name",
+        "description": "If different electrode types are used,\nplease use the corresponding table in the `_electrodes.tsv` file.\n",
+        "type": "string"
+      },
+      "EpochLength": {
+        "name": "EpochLength",
+        "display_name": "Epoch Length",
+        "description": "Duration of individual epochs in seconds (for example, `1`)\nin case of epoched data.\nIf recording was continuous or discontinuous, leave out the field.\n",
+        "type": "number",
+        "minimum": 0
+      },
+      "EstimationAlgorithm": {
+        "name": "EstimationAlgorithm",
+        "display_name": "Estimation Algorithm",
+        "description": "Type of algorithm used to perform fitting\n(for example, `\"linear\"`, `\"non-linear\"`, `\"LM\"` and such).\n",
+        "type": "string"
+      },
+      "EstimationReference": {
+        "name": "EstimationReference",
+        "display_name": "Estimation Reference",
+        "description": "Reference to the study/studies on which the implementation is based.\n",
+        "type": "string"
+      },
+      "EthicsApprovals": {
+        "name": "EthicsApprovals",
+        "display_name": "Ethics Approvals",
+        "description": "List of ethics committee approvals of the research protocols and/or\nprotocol identifiers.\n",
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "FiducialsCoordinateSystem": {
+        "name": "FiducialsCoordinateSystem",
+        "display_name": "Fiducials Coordinate System",
+        "description": "Defines the coordinate system for the fiducials.\nPreferably the same as the `\"EEGCoordinateSystem\"`.\nSee the\n[Coordinate Systems Appendix](SPEC_ROOT/appendices/coordinate-systems.md)\nfor a list of restricted keywords for coordinate systems.\nIf `\"Other\"`, provide definition of the coordinate system in\n`\"FiducialsCoordinateSystemDescription\"`.\n",
+        "type": "string",
+        "enum": [
+          "CTF",
+          "ElektaNeuromag",
+          "4DBti",
+          "KitYokogawa",
+          "ChietiItab",
+          "Other",
+          "CapTrak",
+          "EEGLAB",
+          "EEGLAB-HJ",
+          "Other",
+          "ICBM452AirSpace",
+          "ICBM452Warp5Space",
+          "IXI549Space",
+          "fsaverage",
+          "fsaverageSym",
+          "fsLR",
+          "MNIColin27",
+          "MNI152Lin",
+          "MNI152NLin2009aSym",
+          "MNI152NLin2009bSym",
+          "MNI152NLin2009cSym",
+          "MNI152NLin2009aAsym",
+          "MNI152NLin2009bAsym",
+          "MNI152NLin2009cAsym",
+          "MNI152NLin6Sym",
+          "MNI152NLin6ASym",
+          "MNI305",
+          "NIHPD",
+          "OASIS30AntsOASISAnts",
+          "OASIS30Atropos",
+          "Talairach",
+          "UNCInfant",
+          "fsaverage3",
+          "fsaverage4",
+          "fsaverage5",
+          "fsaverage6",
+          "fsaveragesym",
+          "UNCInfant0V21",
+          "UNCInfant1V21",
+          "UNCInfant2V21",
+          "UNCInfant0V22",
+          "UNCInfant1V22",
+          "UNCInfant2V22",
+          "UNCInfant0V23",
+          "UNCInfant1V23",
+          "UNCInfant2V23"
+        ]
+      },
+      "FiducialsCoordinateSystemDescription": {
+        "name": "FiducialsCoordinateSystemDescription",
+        "display_name": "Fiducials Coordinate System Description",
+        "description": "Free-form text description of the coordinate system.\nMay also include a link to a documentation page or paper describing the\nsystem in greater detail.\n",
+        "type": "string"
+      },
+      "FiducialsCoordinateUnits": {
+        "name": "FiducialsCoordinateUnits",
+        "display_name": "Fiducials Coordinate Units",
+        "description": "Units in which the coordinates that are  listed in the field\n`\"FiducialsCoordinateSystem\"` are represented.\n",
+        "type": "string",
+        "enum": [
+          "m",
+          "mm",
+          "cm",
+          "n/a"
+        ]
+      },
+      "FiducialsCoordinates": {
+        "name": "FiducialsCoordinates",
+        "display_name": "Fiducials Coordinates",
+        "description": "Key-value pairs of the labels and 3-D digitized position of anatomical\nlandmarks, interpreted following the `\"FiducialsCoordinateSystem\"`\n(for example, `{\"NAS\": [12.7,21.3,13.9], \"LPA\": [5.2,11.3,9.6],\n\"RPA\": [20.2,11.3,9.1]}`).\nEach array MUST contain three numeric values corresponding to x, y, and z\naxis of the coordinate system in that exact order.\n",
+        "type": "object",
+        "additionalProperties": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 3,
+          "maxItems": 3
+        }
+      },
+      "FiducialsDescription": {
+        "name": "FiducialsDescription",
+        "display_name": "Fiducials Description",
+        "description": "Free-form text description of how the fiducials such as vitamin-E capsules\nwere placed relative to anatomical landmarks,\nand how the position of the fiducials were measured\n(for example, `\"both with Polhemus and with T1w MRI\"`).\n",
+        "type": "string"
+      },
+      "FlipAngle": {
+        "name": "FlipAngle",
+        "display_name": "Flip Angle",
+        "description": "Flip angle (FA) for the acquisition, specified in degrees.\nCorresponds to: DICOM Tag 0018, 1314 `Flip Angle`.\nThe data type number may apply to files from any MRI modality concerned with\na single value for this field, or to the files in a\n[file collection](SPEC_ROOT/appendices/file-collections.md)\nwhere the value of this field is iterated using the\n[`flip` entity](SPEC_ROOT/appendices/entities.md#flip).\nThe data type array provides a value for each volume in a 4D dataset and\nshould only be used when the volume timing is critical for interpretation of\nthe data, such as in\n[ASL](SPEC_ROOT/04-modality-specific-files/01-magnetic-resonance-imaging-data.md#\\\narterial-spin-labeling-perfusion-data)\nor variable flip angle fMRI sequences.\n",
+        "anyOf": [
+          {
+            "type": "number",
+            "unit": "degree",
+            "exclusiveMinimum": 0,
+            "maximum": 360
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "unit": "degree",
+              "exclusiveMinimum": 0,
+              "maximum": 360
+            }
+          }
+        ]
+      },
+      "FrameDuration": {
+        "name": "FrameDuration",
+        "display_name": "Frame Duration",
+        "description": "Time duration of each frame in default unit seconds.\nThis corresponds to DICOM Tag 0018, 1242 `Actual Frame Duration` converted\nto seconds.\n",
+        "type": "array",
+        "items": {
+          "type": "number"
+        },
+        "unit": "s"
+      },
+      "FrameTimesStart": {
+        "name": "FrameTimesStart",
+        "display_name": "Frame Times Start",
+        "description": "Start times for all frames relative to `\"TimeZero\"` in default unit seconds.\n",
+        "type": "array",
+        "items": {
+          "type": "number"
+        },
+        "unit": "s"
+      },
+      "Funding": {
+        "name": "Funding",
+        "display_name": "Funding",
+        "description": "List of sources of funding (grant numbers).\n",
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "GeneratedBy": {
+        "name": "GeneratedBy",
+        "display_name": "Generated By",
+        "description": "Used to specify provenance of the dataset.\n",
+        "type": "array",
+        "minItems": 1,
+        "items": {
+          "type": "object",
+          "properties": {
+            "Name": {
+              "type": "string"
+            },
+            "Version": {
+              "type": "string"
+            },
+            "Description": {
+              "type": "string"
+            },
+            "CodeURL": {
+              "type": "string",
+              "format": "uri"
+            },
+            "Container": {
+              "type": "object",
+              "properties": {
+                "Type": {
+                  "type": "string"
+                },
+                "Tag": {
+                  "type": "string"
+                },
+                "URI": {
+                  "type": "string",
+                  "format": "uri"
+                }
+              }
+            }
+          }
+        }
+      },
+      "GeneticLevel": {
+        "name": "GeneticLevel",
+        "display_name": "Genetic Level",
+        "description": "Describes the level of analysis.\nValues MUST be one of `\"Genetic\"`, `\"Genomic\"`, `\"Epigenomic\"`,\n`\"Transcriptomic\"`, `\"Metabolomic\"`, or `\"Proteomic\"`.\n",
+        "anyOf": [
+          {
+            "type": "string",
+            "enum": [
+              "Genetic",
+              "Genomic",
+              "Epigenomic",
+              "Transcriptomic",
+              "Metabolomic",
+              "Proteomic"
+            ]
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "Genetic",
+                "Genomic",
+                "Epigenomic",
+                "Transcriptomic",
+                "Metabolomic",
+                "Proteomic"
+              ]
+            }
+          }
+        ]
+      },
+      "Genetics": {
+        "name": "Genetics",
+        "display_name": "Genetics",
+        "description": "An object containing information about the genetics descriptor.\n",
+        "type": "object",
+        "properties": {
+          "Database": {
+            "name": "Database",
+            "description": "[URI](SPEC_ROOT/02-common-principles.md#uniform-resource-indicator)\nof database where the dataset is hosted.\n",
+            "type": "string",
+            "format": "uri"
+          },
+          "Dataset": {
+            "name": "Dataset",
+            "description": "[URI](SPEC_ROOT/02-common-principles.md#uniform-resource-indicator)\nwhere data can be retrieved.\n",
+            "type": "string",
+            "format": "uri"
+          },
+          "Descriptors": {
+            "name": "Descriptors",
+            "description": "List of relevant descriptors (for example, journal articles) for dataset\nusing a valid\n[URI](SPEC_ROOT/02-common-principles.md#uniform-resource-indicator)\nwhen possible.\n",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            ]
+          }
+        }
+      },
+      "GradientSetType": {
+        "name": "GradientSetType",
+        "display_name": "Gradient Set Type",
+        "description": "It should be possible to infer the gradient coil from the scanner model.\nIf not, for example because of a custom upgrade or use of a gradient\ninsert set, then the specifications of the actual gradient coil should be\nreported independently.\n",
+        "type": "string"
+      },
+      "GYROChannelCount": {
+        "name": "GYROChannelCount",
+        "display_name": "Gyrometer Channel Count",
+        "description": "Number of gyrometer channels.\n",
+        "type": "integer",
+        "minimum": 0
+      },
+      "HED": {
+        "name": "HED",
+        "display_name": "HED",
+        "description": "Hierarchical Event Descriptor (HED) information,\nsee the [HED Appendix](SPEC_ROOT/appendices/hed.md) for details.\n",
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "HEDVersion": {
+        "name": "HEDVersion",
+        "display_name": "HED Version",
+        "description": "If HED tags are used:\nThe version of the HED schema used to validate HED tags for study.\nMay include a single schema or a base schema and one or more library schema.\n",
+        "anyOf": [
+          {
+            "type": "string",
+            "format": "hed_version"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "hed_version"
+            }
+          }
+        ]
+      },
+      "Haematocrit": {
+        "name": "Haematocrit",
+        "display_name": "Haematocrit",
+        "description": "Measured haematocrit, meaning the volume of erythrocytes divided by the\nvolume of whole blood.\n",
+        "type": "number"
+      },
+      "HardcopyDeviceSoftwareVersion": {
+        "name": "HardcopyDeviceSoftwareVersion",
+        "display_name": "Hardcopy Device Software Version",
+        "description": "Manufacturer's designation of the software of the device that created this\nHardcopy Image (the printer).\nCorresponds to DICOM Tag 0018, 101A `Hardcopy Device Software Version`.\n",
+        "type": "string"
+      },
+      "HardwareFilters": {
+        "name": "HardwareFilters",
+        "display_name": "Hardware Filters",
+        "description": "Object of temporal hardware filters applied, or `\"n/a\"` if the data is not\navailable. Each key-value pair in the JSON object is a name of the filter and\nan object in which its parameters are defined as key-value pairs.\nFor example, `{\"Highpass RC filter\": {\"Half amplitude cutoff (Hz)\":\n0.0159, \"Roll-off\": \"6dB/Octave\"}}`.\n",
+        "anyOf": [
+          {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object"
+            }
+          },
+          {
+            "type": "string",
+            "enum": [
+              "n/a"
+            ]
+          }
+        ]
+      },
+      "HeadCircumference": {
+        "name": "HeadCircumference",
+        "display_name": "Head Circumference",
+        "description": "Circumference of the participant's head, expressed in cm (for example, `58`).\n",
+        "type": "number",
+        "exclusiveMinimum": 0,
+        "unit": "cm"
+      },
+      "HeadCoilCoordinateSystem": {
+        "name": "HeadCoilCoordinateSystem",
+        "display_name": "Head Coil Coordinate System",
+        "description": "Defines the coordinate system for the head coils.\nSee the\n[Coordinate Systems Appendix](SPEC_ROOT/appendices/coordinate-systems.md)\nfor a list of restricted keywords for coordinate systems.\nIf `\"Other\"`, provide definition of the coordinate system in\n`HeadCoilCoordinateSystemDescription`.\n",
+        "type": "string",
+        "enum": [
+          "CTF",
+          "ElektaNeuromag",
+          "4DBti",
+          "KitYokogawa",
+          "ChietiItab",
+          "Other",
+          "CapTrak",
+          "EEGLAB",
+          "EEGLAB-HJ",
+          "Other",
+          "ICBM452AirSpace",
+          "ICBM452Warp5Space",
+          "IXI549Space",
+          "fsaverage",
+          "fsaverageSym",
+          "fsLR",
+          "MNIColin27",
+          "MNI152Lin",
+          "MNI152NLin2009aSym",
+          "MNI152NLin2009bSym",
+          "MNI152NLin2009cSym",
+          "MNI152NLin2009aAsym",
+          "MNI152NLin2009bAsym",
+          "MNI152NLin2009cAsym",
+          "MNI152NLin6Sym",
+          "MNI152NLin6ASym",
+          "MNI305",
+          "NIHPD",
+          "OASIS30AntsOASISAnts",
+          "OASIS30Atropos",
+          "Talairach",
+          "UNCInfant",
+          "fsaverage3",
+          "fsaverage4",
+          "fsaverage5",
+          "fsaverage6",
+          "fsaveragesym",
+          "UNCInfant0V21",
+          "UNCInfant1V21",
+          "UNCInfant2V21",
+          "UNCInfant0V22",
+          "UNCInfant1V22",
+          "UNCInfant2V22",
+          "UNCInfant0V23",
+          "UNCInfant1V23",
+          "UNCInfant2V23"
+        ]
+      },
+      "HeadCoilCoordinateSystemDescription": {
+        "name": "HeadCoilCoordinateSystemDescription",
+        "display_name": "Head Coil Coordinate System Description",
+        "description": "Free-form text description of the coordinate system.\nMay also include a link to a documentation page or paper describing the system in greater detail.\n",
+        "type": "string"
+      },
+      "HeadCoilCoordinateUnits": {
+        "name": "HeadCoilCoordinateUnits",
+        "display_name": "Head Coil Coordinate Units",
+        "description": "Units of the coordinates of `HeadCoilCoordinateSystem`.\n",
+        "type": "string",
+        "enum": [
+          "m",
+          "mm",
+          "cm",
+          "n/a"
+        ]
+      },
+      "HeadCoilCoordinates": {
+        "name": "HeadCoilCoordinates",
+        "display_name": "Head Coil Coordinates",
+        "description": "Key-value pairs describing head localization coil labels and their\ncoordinates, interpreted following the `HeadCoilCoordinateSystem`\n(for example, `{\"NAS\": [12.7,21.3,13.9], \"LPA\": [5.2,11.3,9.6],\n\"RPA\": [20.2,11.3,9.1]}`).\nNote that coils are not always placed at locations that have a known\nanatomical name (for example, for Elekta, Yokogawa systems); in that case\ngeneric labels can be used\n(for example, `{\"coil1\": [12.2,21.3,12.3], \"coil2\": [6.7,12.3,8.6],\n\"coil3\": [21.9,11.0,8.1]}`).\nEach array MUST contain three numeric values corresponding to x, y, and z\naxis of the coordinate system in that exact order.\n",
+        "type": "object",
+        "additionalProperties": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 3,
+          "maxItems": 3
+        }
+      },
+      "HeadCoilFrequency": {
+        "name": "HeadCoilFrequency",
+        "display_name": "Head Coil Frequency",
+        "description": "List of frequencies (in Hz) used by the head localisation coils\n('HLC' in CTF systems, 'HPI' in Elekta, 'COH' in BTi/4D)\nthat track the subject's head position in the MEG helmet\n(for example, `[293, 307, 314, 321]`).\n",
+        "anyOf": [
+          {
+            "type": "number",
+            "unit": "Hz"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "unit": "Hz"
+            }
+          }
+        ]
+      },
+      "HowToAcknowledge": {
+        "name": "HowToAcknowledge",
+        "display_name": "How To Acknowledge",
+        "description": "Text containing instructions on how researchers using this dataset should\nacknowledge the original authors.\nThis field can also be used to define a publication that should be cited in\npublications that use the dataset.\n",
+        "type": "string"
+      },
+      "ImageAcquisitionProtocol": {
+        "name": "ImageAcquisitionProtocol",
+        "display_name": "Image Acquisition Protocol",
+        "description": "Description of the image acquisition protocol or\n[URI](SPEC_ROOT/02-common-principles.md#uniform-resource-indicator)\n(for example from [protocols.io](https://www.protocols.io/)).\n",
+        "type": "string"
+      },
+      "ImageDecayCorrected": {
+        "name": "ImageDecayCorrected",
+        "display_name": "Image Decay Corrected",
+        "description": "Boolean flag specifying whether the image data have been decay-corrected.\n",
+        "type": "boolean"
+      },
+      "ImageDecayCorrectionTime": {
+        "name": "ImageDecayCorrectionTime",
+        "display_name": "Image Decay Correction Time",
+        "description": "Point in time from which the decay correction was applied with respect to\n`\"TimeZero\"` in the default unit seconds.\n",
+        "type": "number",
+        "unit": "s"
+      },
+      "Immersion": {
+        "name": "Immersion",
+        "display_name": "Immersion",
+        "description": "Lens immersion medium. If the file format is OME-TIFF, the value MUST be consistent\nwith the `Immersion` OME metadata field.\n",
+        "type": "string"
+      },
+      "InfusionRadioactivity": {
+        "name": "InfusionRadioactivity",
+        "display_name": "Infusion Radioactivity",
+        "description": "Amount of radioactivity infused into the patient.\nThis value must be less than or equal to the total injected radioactivity\n(`\"InjectedRadioactivity\"`).\nUnits should be the same as `\"InjectedRadioactivityUnits\"`.\n",
+        "type": "number"
+      },
+      "InfusionSpeed": {
+        "name": "InfusionSpeed",
+        "display_name": "Infusion Speed",
+        "description": "If given, infusion speed.\n",
+        "type": "number"
+      },
+      "InfusionSpeedUnits": {
+        "name": "InfusionSpeedUnits",
+        "display_name": "Infusion Speed Units",
+        "description": "Unit of infusion speed (for example, `\"mL/s\"`).\n",
+        "type": "string",
+        "format": "unit"
+      },
+      "InfusionStart": {
+        "name": "InfusionStart",
+        "display_name": "Infusion Start",
+        "description": "Time of start of infusion with respect to `\"TimeZero\"` in the default unit\nseconds.\n",
+        "type": "number",
+        "unit": "s"
+      },
+      "InjectedMass": {
+        "name": "InjectedMass",
+        "display_name": "Injected Mass",
+        "description": "Total mass of radiolabeled compound injected into subject (for example, `10`).\nThis can be derived as the ratio of the `\"InjectedRadioactivity\"` and\n`\"MolarRadioactivity\"`.\n**For those tracers in which injected mass is not available (for example FDG)\ncan be set to `\"n/a\"`)**.\n",
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "n/a"
+            ]
+          }
+        ]
+      },
+      "InjectedMassPerWeight": {
+        "name": "InjectedMassPerWeight",
+        "display_name": "Injected Mass Per Weight",
+        "description": "Injected mass per kilogram bodyweight.\n",
+        "type": "number"
+      },
+      "InjectedMassPerWeightUnits": {
+        "name": "InjectedMassPerWeightUnits",
+        "display_name": "Injected Mass Per Weight Units",
+        "description": "Unit format of the injected mass per kilogram bodyweight\n(for example, `\"ug/kg\"`).\n",
+        "type": "string",
+        "format": "unit"
+      },
+      "InjectedMassUnits": {
+        "name": "InjectedMassUnits",
+        "display_name": "Injected Mass Units",
+        "description": "Unit format of the mass of compound injected (for example, `\"ug\"` or\n`\"umol\"`).\n**Note this is not required for an FDG acquisition, since it is not available,\nand SHOULD be set to `\"n/a\"`**.\n",
+        "anyOf": [
+          {
+            "type": "string",
+            "format": "unit"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "n/a"
+            ]
+          }
+        ]
+      },
+      "InjectedRadioactivity": {
+        "name": "InjectedRadioactivity",
+        "display_name": "Injected Radioactivity",
+        "description": "Total amount of radioactivity injected into the patient (for example, `400`).\nFor bolus-infusion experiments, this value should be the sum of all injected\nradioactivity originating from both bolus and infusion.\nCorresponds to DICOM Tag 0018, 1074 `Radionuclide Total Dose`.\n",
+        "type": "number"
+      },
+      "InjectedRadioactivityUnits": {
+        "name": "InjectedRadioactivityUnits",
+        "display_name": "Injected Radioactivity Units",
+        "description": "Unit format of the specified injected radioactivity (for example, `\"MBq\"`).\n",
+        "type": "string",
+        "format": "unit"
+      },
+      "InjectedVolume": {
+        "name": "InjectedVolume",
+        "display_name": "Injected Volume",
+        "description": "Injected volume of the radiotracer in the unit `\"mL\"`.\n",
+        "type": "number",
+        "unit": "mL"
+      },
+      "InjectionEnd": {
+        "name": "InjectionEnd",
+        "display_name": "Injection End",
+        "description": "Time of end of injection with respect to `\"TimeZero\"` in the default unit\nseconds.\n",
+        "type": "number",
+        "unit": "s"
+      },
+      "InjectionStart": {
+        "name": "InjectionStart",
+        "display_name": "Injection Start",
+        "description": "Time of start of injection with respect to `\"TimeZero\"` in the default unit\nseconds.\nThis corresponds to DICOM Tag 0018, 1072 `Contrast/Bolus Start Time`\nconverted to seconds relative to `\"TimeZero\"`.\n",
+        "type": "number",
+        "unit": "s"
+      },
+      "InstitutionAddress": {
+        "name": "InstitutionAddress",
+        "display_name": "Institution Address",
+        "description": "The address of the institution in charge of the equipment that produced the\nmeasurements.\n",
+        "type": "string"
+      },
+      "InstitutionName": {
+        "name": "InstitutionName",
+        "display_name": "Institution Name",
+        "description": "The name of the institution in charge of the equipment that produced the\nmeasurements.\n",
+        "type": "string"
+      },
+      "InstitutionalDepartmentName": {
+        "name": "InstitutionalDepartmentName",
+        "display_name": "Institutional Department Name",
+        "description": "The department in the institution in charge of the equipment that produced\nthe measurements.\n",
+        "type": "string"
+      },
+      "Instructions": {
+        "name": "Instructions",
+        "display_name": "Instructions",
+        "description": "Text of the instructions given to participants before the recording.\n",
+        "type": "string"
+      },
+      "IntendedFor": {
+        "name": "IntendedFor",
+        "display_name": "Intended For",
+        "description": "The paths to files for which the associated file is intended to be used.\nContains one or more [BIDS URIs](SPEC_ROOT/02-common-principles.md#bids-uri).\nUsing forward-slash separated paths relative to the participant subdirectory is\n[DEPRECATED](SPEC_ROOT/02-common-principles.md#definitions).\n",
+        "anyOf": [
+          {
+            "type": "string",
+            "format": "bids_uri"
+          },
+          {
+            "type": "string",
+            "format": "participant_relative"
+          },
+          {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "bids_uri"
+                },
+                {
+                  "type": "string",
+                  "format": "participant_relative"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "IntendedFor__ds_relative": {
+        "name": "IntendedFor",
+        "display_name": "Intended For",
+        "description": "The paths to files for which the associated file is intended to be used.\nContains one or more [BIDS URIs](SPEC_ROOT/02-common-principles.md#bids-uri).\nUsing forward-slash separated paths relative to the dataset root is\n[DEPRECATED](SPEC_ROOT/02-common-principles.md#definitions).\n",
+        "anyOf": [
+          {
+            "type": "string",
+            "format": "bids_uri"
+          },
+          {
+            "type": "string",
+            "format": "dataset_relative"
+          },
+          {
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "bids_uri"
+                },
+                {
+                  "type": "string",
+                  "format": "dataset_relative"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "InversionTime": {
+        "name": "InversionTime",
+        "display_name": "Inversion Time",
+        "description": "The inversion time (TI) for the acquisition, specified in seconds.\nInversion time is the time after the middle of inverting RF pulse to middle\nof excitation pulse to detect the amount of longitudinal magnetization.\nCorresponds to DICOM Tag 0018, 0082 `Inversion Time`\n(please note that the DICOM term is in milliseconds not seconds).\n",
+        "type": "number",
+        "unit": "s",
+        "exclusiveMinimum": 0
+      },
+      "LabelingDistance": {
+        "name": "LabelingDistance",
+        "display_name": "Labeling Distance",
+        "description": "Distance from the center of the imaging slab to the center of the labeling\nplane (`(P)CASL`) or the leading edge of the labeling slab (`PASL`),\nin millimeters.\nIf the labeling is performed inferior to the isocenter,\nthis number should be negative.\nBased on DICOM macro C.8.13.5.14.\n",
+        "type": "number",
+        "unit": "mm"
+      },
+      "LabelingDuration": {
+        "name": "LabelingDuration",
+        "display_name": "Labeling Duration",
+        "description": "Total duration of the labeling pulse train, in seconds,\ncorresponding to the temporal width of the labeling bolus for\n`\"PCASL\"` or `\"CASL\"`.\nIn case all control-label volumes (or deltam or CBF) have the same\n`LabelingDuration`, a scalar must be specified.\nIn case the control-label volumes (or deltam or cbf) have a different\n`\"LabelingDuration\"`, an array of numbers must be specified,\nfor which any `m0scan` in the timeseries has a `\"LabelingDuration\"` of zero.\nIn case an array of numbers is provided,\nits length should be equal to the number of volumes specified in\n`*_aslcontext.tsv`.\nCorresponds to DICOM Tag 0018, 9258 `ASL Pulse Train Duration`.\n",
+        "anyOf": [
+          {
+            "type": "number",
+            "minimum": 0,
+            "unit": "s"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "unit": "s",
+              "minimum": 0
+            }
+          }
+        ]
+      },
+      "LabelingEfficiency": {
+        "name": "LabelingEfficiency",
+        "display_name": "Labeling Efficiency",
+        "description": "Labeling efficiency, specified as a number between zero and one,\nonly if obtained externally (for example phase-contrast based).\n",
+        "type": "number",
+        "exclusiveMinimum": 0
+      },
+      "LabelingLocationDescription": {
+        "name": "LabelingLocationDescription",
+        "display_name": "Labeling Location Description",
+        "description": "Description of the location of the labeling plane (`\"CASL\"` or `\"PCASL\"`) or\nthe labeling slab (`\"PASL\"`) that cannot be captured by fields\n`LabelingOrientation` or `LabelingDistance`.\nMay include a link to an anonymized screenshot of the planning of the\nlabeling slab/plane with respect to the imaging slab or slices\n`*_asllabeling.jpg`.\nBased on DICOM macro C.8.13.5.14.\n",
+        "type": "string"
+      },
+      "LabelingOrientation": {
+        "name": "LabelingOrientation",
+        "display_name": "Labeling Orientation",
+        "description": "Orientation of the labeling plane (`(P)CASL`) or slab (`PASL`).\nThe direction cosines of a normal vector perpendicular to the ASL labeling\nslab or plane with respect to the patient.\nCorresponds to DICOM Tag 0018, 9255 `ASL Slab Orientation`.\n",
+        "type": "array",
+        "items": {
+          "type": "number"
+        }
+      },
+      "LabelingPulseAverageB1": {
+        "name": "LabelingPulseAverageB1",
+        "display_name": "Labeling Pulse Average B1",
+        "description": "The average B1-field strength of the RF labeling pulses, in microteslas.\nAs an alternative, `\"LabelingPulseFlipAngle\"` can be provided.\n",
+        "type": "number",
+        "exclusiveMinimum": 0,
+        "unit": "uT"
+      },
+      "LabelingPulseAverageGradient": {
+        "name": "LabelingPulseAverageGradient",
+        "display_name": "Labeling Pulse Average Gradient",
+        "description": "The average labeling gradient, in milliteslas per meter.\n",
+        "type": "number",
+        "exclusiveMinimum": 0,
+        "unit": "mT/m"
+      },
+      "LabelingPulseDuration": {
+        "name": "LabelingPulseDuration",
+        "display_name": "Labeling Pulse Duration",
+        "description": "Duration of the individual labeling pulses, in milliseconds.\n",
+        "type": "number",
+        "exclusiveMinimum": 0,
+        "unit": "ms"
+      },
+      "LabelingPulseFlipAngle": {
+        "name": "LabelingPulseFlipAngle",
+        "display_name": "Labeling Pulse Flip Angle",
+        "description": "The flip angle of a single labeling pulse, in degrees,\nwhich can be given as an alternative to `\"LabelingPulseAverageB1\"`.\n",
+        "type": "number",
+        "exclusiveMinimum": 0,
+        "maximum": 360,
+        "unit": "degree"
+      },
+      "LabelingPulseInterval": {
+        "name": "LabelingPulseInterval",
+        "display_name": "Labeling Pulse Interval",
+        "description": "Delay between the peaks of the individual labeling pulses, in milliseconds.\n",
+        "type": "number",
+        "exclusiveMinimum": 0,
+        "unit": "ms"
+      },
+      "LabelingPulseMaximumGradient": {
+        "name": "LabelingPulseMaximumGradient",
+        "display_name": "Labeling Pulse Maximum Gradient",
+        "description": "The maximum amplitude of the gradient switched on during the application of\nthe labeling RF pulse(s), in milliteslas per meter.\n",
+        "type": "number",
+        "exclusiveMinimum": 0,
+        "unit": "mT/m"
+      },
+      "LabelingSlabThickness": {
+        "name": "LabelingSlabThickness",
+        "display_name": "Labeling Slab Thickness",
+        "description": "Thickness of the labeling slab in millimeters.\nFor non-selective FAIR a zero is entered.\nCorresponds to DICOM Tag 0018, 9254 `ASL Slab Thickness`.\n",
+        "type": "number",
+        "exclusiveMinimum": 0,
+        "unit": "mm"
+      },
+      "Levels": {
+        "name": "Levels",
+        "display_name": "Levels",
+        "description": "For categorical variables: An object of possible values (keys) and their\ndescriptions (values).\n",
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      },
+      "License": {
+        "name": "License",
+        "display_name": "License",
+        "description": "The license for the dataset.\nThe use of license name abbreviations is RECOMMENDED for specifying a license\n(see [Licenses](SPEC_ROOT/appendices/licenses.md)).\nThe corresponding full license text MAY be specified in an additional\n`LICENSE` file.\n",
+        "type": "string"
+      },
+      "LongName": {
+        "name": "LongName",
+        "display_name": "Long Name",
+        "description": "Long (unabbreviated) name of the column.\n",
+        "type": "string"
+      },
+      "LookLocker": {
+        "name": "LookLocker",
+        "display_name": "Look Locker",
+        "description": "Boolean indicating if a Look-Locker readout is used.\n",
+        "type": "boolean"
+      },
+      "M0Estimate": {
+        "name": "M0Estimate",
+        "display_name": "M0Estimate",
+        "description": "A single numerical whole-brain M0 value (referring to the M0 of blood),\nonly if obtained externally\n(for example retrieved from CSF in a separate measurement).\n",
+        "type": "number",
+        "exclusiveMinimum": 0
+      },
+      "M0Type": {
+        "name": "M0Type",
+        "display_name": "M0Type",
+        "description": "Describes the presence of M0 information.\n`\"Separate\"` means that a separate `*_m0scan.nii[.gz]` is present.\n`\"Included\"` means that an m0scan volume is contained within the current\n`*_asl.nii[.gz]`.\n`\"Estimate\"` means that a single whole-brain M0 value is provided.\n`\"Absent\"` means that no specific M0 information is present.\n",
+        "type": "string",
+        "enum": [
+          "Separate",
+          "Included",
+          "Estimate",
+          "Absent"
+        ]
+      },
+      "MAGNChannelCount": {
+        "name": "MAGNChannelCount",
+        "display_name": "Magnetometer Channel Count",
+        "description": "Number of magnetometer channels.\n",
+        "type": "integer",
+        "minimum": 0
+      },
+      "MEGChannelCount": {
+        "name": "MEGChannelCount",
+        "display_name": "MEG Channel Count",
+        "description": "Number of MEG channels (for example, `275`).\n",
+        "type": "integer",
+        "minimum": 0
+      },
+      "MEGCoordinateSystem": {
+        "name": "MEGCoordinateSystem",
+        "display_name": "MEG Coordinate System",
+        "description": "Defines the coordinate system for the MEG sensors.\nSee the\n[Coordinate Systems Appendix](SPEC_ROOT/appendices/coordinate-systems.md)\nfor a list of restricted keywords for coordinate systems.\nIf `\"Other\"`, provide definition of the coordinate system in\n`\"MEGCoordinateSystemDescription\"`.\n",
+        "type": "string",
+        "enum": [
+          "CTF",
+          "ElektaNeuromag",
+          "4DBti",
+          "KitYokogawa",
+          "ChietiItab",
+          "Other",
+          "CapTrak",
+          "EEGLAB",
+          "EEGLAB-HJ",
+          "Other",
+          "ICBM452AirSpace",
+          "ICBM452Warp5Space",
+          "IXI549Space",
+          "fsaverage",
+          "fsaverageSym",
+          "fsLR",
+          "MNIColin27",
+          "MNI152Lin",
+          "MNI152NLin2009aSym",
+          "MNI152NLin2009bSym",
+          "MNI152NLin2009cSym",
+          "MNI152NLin2009aAsym",
+          "MNI152NLin2009bAsym",
+          "MNI152NLin2009cAsym",
+          "MNI152NLin6Sym",
+          "MNI152NLin6ASym",
+          "MNI305",
+          "NIHPD",
+          "OASIS30AntsOASISAnts",
+          "OASIS30Atropos",
+          "Talairach",
+          "UNCInfant",
+          "fsaverage3",
+          "fsaverage4",
+          "fsaverage5",
+          "fsaverage6",
+          "fsaveragesym",
+          "UNCInfant0V21",
+          "UNCInfant1V21",
+          "UNCInfant2V21",
+          "UNCInfant0V22",
+          "UNCInfant1V22",
+          "UNCInfant2V22",
+          "UNCInfant0V23",
+          "UNCInfant1V23",
+          "UNCInfant2V23"
+        ]
+      },
+      "MEGCoordinateSystemDescription": {
+        "name": "MEGCoordinateSystemDescription",
+        "display_name": "MEG Coordinate System Description",
+        "description": "Free-form text description of the coordinate system.\nMay also include a link to a documentation page or paper describing the\nsystem in greater detail.\n",
+        "type": "string"
+      },
+      "MEGCoordinateUnits": {
+        "name": "MEGCoordinateUnits",
+        "display_name": "MEG Coordinate Units",
+        "description": "Units of the coordinates of `\"MEGCoordinateSystem\"`.\n",
+        "type": "string",
+        "enum": [
+          "m",
+          "mm",
+          "cm",
+          "n/a"
+        ]
+      },
+      "MEGREFChannelCount": {
+        "name": "MEGREFChannelCount",
+        "display_name": "MEGREF Channel Count",
+        "description": "Number of MEG reference channels (for example, `23`).\nFor systems without such channels (for example, Neuromag Vectorview),\n`MEGREFChannelCount` should be set to `0`.\n",
+        "type": "integer",
+        "minimum": 0
+      },
+      "MRAcquisitionType": {
+        "name": "MRAcquisitionType",
+        "display_name": "MR Acquisition Type",
+        "description": "Type of sequence readout.\nCorresponds to DICOM Tag 0018, 0023 `MR Acquisition Type`.\n",
+        "type": "string",
+        "enum": [
+          "2D",
+          "3D"
+        ]
+      },
+      "MRTransmitCoilSequence": {
+        "name": "MRTransmitCoilSequence",
+        "display_name": "MR Transmit Coil Sequence",
+        "description": "This is a relevant field if a non-standard transmit coil is used.\nCorresponds to DICOM Tag 0018, 9049 `MR Transmit Coil Sequence`.\n",
+        "type": "string"
+      },
+      "MTNumberOfPulses": {
+        "name": "MTNumberOfPulses",
+        "display_name": "MT Number Of Pulses",
+        "description": "The number of magnetization transfer RF pulses applied before the readout.\n",
+        "type": "number"
+      },
+      "MTOffsetFrequency": {
+        "name": "MTOffsetFrequency",
+        "display_name": "MT Offset Frequency",
+        "description": "The frequency offset of the magnetization transfer pulse with respect to the\ncentral H1 Larmor frequency in Hertz (Hz).\n",
+        "type": "number",
+        "unit": "Hz"
+      },
+      "MTPulseBandwidth": {
+        "name": "MTPulseBandwidth",
+        "display_name": "MT Pulse Bandwidth",
+        "description": "The excitation bandwidth of the magnetization transfer pulse in Hertz (Hz).\n",
+        "type": "number",
+        "unit": "Hz"
+      },
+      "MTPulseDuration": {
+        "name": "MTPulseDuration",
+        "display_name": "MT Pulse Duration",
+        "description": "Duration of the magnetization transfer RF pulse in seconds.\n",
+        "type": "number",
+        "unit": "s"
+      },
+      "MTPulseShape": {
+        "name": "MTPulseShape",
+        "display_name": "MT Pulse Shape",
+        "description": "Shape of the magnetization transfer RF pulse waveform.\nThe value `\"GAUSSHANN\"` refers to a Gaussian pulse with a Hanning window.\nThe value `\"SINCHANN\"` refers to a sinc pulse with a Hanning window.\nThe value `\"SINCGAUSS\"` refers to a sinc pulse with a Gaussian window.\n",
+        "type": "string",
+        "enum": [
+          "HARD",
+          "GAUSSIAN",
+          "GAUSSHANN",
+          "SINC",
+          "SINCHANN",
+          "SINCGAUSS",
+          "FERMI"
+        ]
+      },
+      "MTState": {
+        "name": "MTState",
+        "display_name": "MT State",
+        "description": "Boolean stating whether the magnetization transfer pulse is applied.\nCorresponds to DICOM Tag 0018, 9020 `Magnetization Transfer`.\n",
+        "type": "boolean"
+      },
+      "MagneticFieldStrength": {
+        "name": "MagneticFieldStrength",
+        "display_name": "Magnetic Field Strength",
+        "description": "Nominal field strength of MR magnet in Tesla.\nCorresponds to DICOM Tag 0018, 0087 `Magnetic Field Strength`.\n",
+        "type": "number"
+      },
+      "Magnification": {
+        "name": "Magnification",
+        "display_name": "Magnification",
+        "description": "Lens magnification (for example: `40`). If the file format is OME-TIFF,\nthe value MUST be consistent with the `\"NominalMagnification\"` OME metadata field.\n",
+        "type": "number",
+        "exclusiveMinimum": 0
+      },
+      "Manual": {
+        "name": "Manual",
+        "display_name": "Manual",
+        "description": "Indicates if the segmentation was performed manually or via an automated\nprocess.\n",
+        "type": "boolean"
+      },
+      "Manufacturer": {
+        "name": "Manufacturer",
+        "display_name": "Manufacturer",
+        "description": "Manufacturer of the equipment that produced the measurements.\n",
+        "type": "string"
+      },
+      "ManufacturersModelName": {
+        "name": "ManufacturersModelName",
+        "display_name": "Manufacturers Model Name",
+        "description": "Manufacturer's model name of the equipment that produced the measurements.\n",
+        "type": "string"
+      },
+      "MatrixCoilMode": {
+        "name": "MatrixCoilMode",
+        "display_name": "Matrix Coil Mode",
+        "description": "(If used)\nA method for reducing the number of independent channels by combining in\nanalog the signals from multiple coil elements.\nThere are typically different default modes when using un-accelerated or\naccelerated (for example, `\"GRAPPA\"`, `\"SENSE\"`) imaging.\n",
+        "type": "string"
+      },
+      "MaxMovement": {
+        "name": "MaxMovement",
+        "display_name": "Max Movement",
+        "description": "Maximum head movement (in mm) detected during the recording,\nas measured by the head localisation coils (for example, `4.8`).\n",
+        "type": "number",
+        "unit": "mm"
+      },
+      "MeasurementToolMetadata": {
+        "name": "MeasurementToolMetadata",
+        "display_name": "Measurement Tool Metadata",
+        "description": "A description of the measurement tool as a whole.\nContains two fields: `\"Description\"` and `\"TermURL\"`.\n`\"Description\"` is a free text description of the measurement tool.\n`\"TermURL\"` is a URL to an entity in an ontology corresponding to this tool.\n",
+        "type": "object",
+        "properties": {
+          "TermURL": {
+            "type": "string",
+            "format": "uri"
+          },
+          "Description": {
+            "type": "string"
+          }
+        }
+      },
+      "MetaboliteAvail": {
+        "name": "MetaboliteAvail",
+        "display_name": "Metabolite Available",
+        "description": "Boolean that specifies if metabolite measurements are available.\nIf `true`, the `metabolite_parent_fraction` column MUST be present in the\ncorresponding `*_blood.tsv` file.\n",
+        "type": "boolean"
+      },
+      "MetaboliteMethod": {
+        "name": "MetaboliteMethod",
+        "display_name": "Metabolite Method",
+        "description": "Method used to measure metabolites.\n",
+        "type": "string"
+      },
+      "MetaboliteRecoveryCorrectionApplied": {
+        "name": "MetaboliteRecoveryCorrectionApplied",
+        "display_name": "Metabolite Recovery Correction Applied",
+        "description": "Metabolite recovery correction from the HPLC, for tracers where it changes\nwith time postinjection.\nIf `true`, the `hplc_recovery_fractions` column MUST be present in the\ncorresponding `*_blood.tsv` file.\n",
+        "type": "boolean"
+      },
+      "MiscChannelCount": {
+        "name": "MiscChannelCount",
+        "display_name": "Misc Channel Count",
+        "description": "Number of miscellaneous analog channels for auxiliary signals.\n",
+        "type": "integer",
+        "minimum": 0
+      },
+      "MixingTime": {
+        "name": "MixingTime",
+        "display_name": "Mixing Time",
+        "description": "In the context of a stimulated- and spin-echo 3D EPI sequence for B1+ mapping,\ncorresponds to the interval between spin- and stimulated-echo pulses.\nIn the context of a diffusion-weighted double spin-echo sequence,\ncorresponds to the interval between two successive diffusion sensitizing\ngradients, specified in seconds.\n",
+        "type": "number",
+        "unit": "s"
+      },
+      "ModeOfAdministration": {
+        "name": "ModeOfAdministration",
+        "display_name": "Mode Of Administration",
+        "description": "Mode of administration of the injection\n(for example, `\"bolus\"`, `\"infusion\"`, or `\"bolus-infusion\"`).\n",
+        "type": "string"
+      },
+      "MolarActivity": {
+        "name": "MolarActivity",
+        "display_name": "Molar Activity",
+        "description": "Molar activity of compound injected.\nCorresponds to DICOM Tag 0018, 1077 `Radiopharmaceutical Specific Activity`.\n",
+        "type": "number"
+      },
+      "MolarActivityMeasTime": {
+        "name": "MolarActivityMeasTime",
+        "display_name": "Molar Activity Measurement Time",
+        "description": "Time to which molar radioactivity measurement above applies in the default\nunit `\"hh:mm:ss\"`.\n",
+        "type": "string",
+        "format": "time"
+      },
+      "MolarActivityUnits": {
+        "name": "MolarActivityUnits",
+        "display_name": "Molar Activity Units",
+        "description": "Unit of the specified molar radioactivity (for example, `\"GBq/umol\"`).\n",
+        "type": "string",
+        "format": "unit"
+      },
+      "MultibandAccelerationFactor": {
+        "name": "MultibandAccelerationFactor",
+        "display_name": "Multiband Acceleration Factor",
+        "description": "The multiband factor, for multiband acquisitions.\n",
+        "type": "number"
+      },
+      "MultipartID": {
+        "name": "MultipartID",
+        "display_name": "MultipartID",
+        "description": "A unique (per participant) label tagging DWI runs that are part of a\nmultipart scan.\n",
+        "type": "string"
+      },
+      "Name": {
+        "name": "Name",
+        "display_name": "Name",
+        "description": "Name of the dataset.\n",
+        "type": "string"
+      },
+      "NegativeContrast": {
+        "name": "NegativeContrast",
+        "display_name": "Negative Contrast",
+        "description": "`true` or `false` value specifying whether increasing voxel intensity\n(within sample voxels) denotes a decreased value with respect to the\ncontrast suffix.\nThis is commonly the case when Cerebral Blood Volume is estimated via\nusage of a contrast agent in conjunction with a T2\\* weighted acquisition\nprotocol.\n",
+        "type": "boolean"
+      },
+      "NIRSChannelCount": {
+        "name": "NIRSChannelCount",
+        "display_name": "NIRS Channel Count",
+        "description": "Total number of NIRS channels, including short channels.\nCorresponds to the number of rows in `channels.tsv` with any NIRS type.\n",
+        "type": "integer",
+        "minimum": 0
+      },
+      "NIRSSourceOptodeCount": {
+        "name": "NIRSSourceOptodeCount",
+        "display_name": "NIRS Source Optode Count",
+        "description": "Number of NIRS sources.\nCorresponds to the number of rows in `optodes.tsv` with type `\"source\"`.\n",
+        "type": "integer",
+        "minimum": 1
+      },
+      "NIRSDetectorOptodeCount": {
+        "name": "NIRSDetectorOptodeCount",
+        "display_name": "NIRS Detector Optode Channel Count",
+        "description": "Number of NIRS detectors.\nCorresponds to the number of rows in `optodes.tsv` with type `\"detector\"`.\n",
+        "type": "integer",
+        "minimum": 1
+      },
+      "NIRSPlacementScheme": {
+        "name": "NIRSPlacementScheme",
+        "display_name": "NIRS Placement Scheme",
+        "description": "Placement scheme of NIRS optodes.\nEither the name of a standardized placement system (for example, `\"10-20\"`)\nor an array of standardized position names (for example, `[\"Cz\", \"Pz\"]`).\nThis field should only be used if a cap was not used.\nIf a standard cap was used, then it should be specified in `CapManufacturer`\nand `CapManufacturersModelName` and this field should be set to `\"n/a\"`\n",
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "NIRSCoordinateSystem": {
+        "name": "NIRSCoordinateSystem",
+        "display_name": "NIRS Coordinate System",
+        "description": "Defines the coordinate system in which the optode positions are expressed.\n\nSee\n[Appendix VIII](SPEC_ROOT/appendices/coordinate-systems.md)\nfor a list of restricted keywords for coordinate systems.\nIf `\"Other\"`, a definition of the coordinate system MUST be\nprovided in `NIRSCoordinateSystemDescription`.\n",
+        "type": "string",
+        "enum": [
+          "CTF",
+          "ElektaNeuromag",
+          "4DBti",
+          "KitYokogawa",
+          "ChietiItab",
+          "Other",
+          "CapTrak",
+          "EEGLAB",
+          "EEGLAB-HJ",
+          "Other",
+          "ICBM452AirSpace",
+          "ICBM452Warp5Space",
+          "IXI549Space",
+          "fsaverage",
+          "fsaverageSym",
+          "fsLR",
+          "MNIColin27",
+          "MNI152Lin",
+          "MNI152NLin2009aSym",
+          "MNI152NLin2009bSym",
+          "MNI152NLin2009cSym",
+          "MNI152NLin2009aAsym",
+          "MNI152NLin2009bAsym",
+          "MNI152NLin2009cAsym",
+          "MNI152NLin6Sym",
+          "MNI152NLin6ASym",
+          "MNI305",
+          "NIHPD",
+          "OASIS30AntsOASISAnts",
+          "OASIS30Atropos",
+          "Talairach",
+          "UNCInfant",
+          "fsaverage3",
+          "fsaverage4",
+          "fsaverage5",
+          "fsaverage6",
+          "fsaveragesym",
+          "UNCInfant0V21",
+          "UNCInfant1V21",
+          "UNCInfant2V21",
+          "UNCInfant0V22",
+          "UNCInfant1V22",
+          "UNCInfant2V22",
+          "UNCInfant0V23",
+          "UNCInfant1V23",
+          "UNCInfant2V23"
+        ]
+      },
+      "NIRSCoordinateSystemDescription": {
+        "name": "NIRSCoordinateSystemDescription",
+        "display_name": "NIRS Coordinate System Description",
+        "description": "Free-form text description of the coordinate system.\nMay also include a link to a documentation page or paper describing the\nsystem in greater detail.\n",
+        "type": "string"
+      },
+      "NIRSCoordinateUnits": {
+        "name": "NIRSCoordinateUnits",
+        "display_name": "NIRS Coordinate Units",
+        "description": "Units of the coordinates of `NIRSCoordinateSystem`.\n",
+        "type": "string",
+        "enum": [
+          "m",
+          "mm",
+          "cm",
+          "n/a"
+        ]
+      },
+      "NIRSCoordinateProcessingDescription": {
+        "name": "NIRSCoordinateProcessingDescription",
+        "display_name": "NIRS Coordinate Processing Description",
+        "description": "Has any post-processing (such as projection) been done on the optode\npositions (for example, `\"surface_projection\"`, `\"n/a\"`).\n",
+        "type": "string"
+      },
+      "NonlinearGradientCorrection": {
+        "name": "NonlinearGradientCorrection",
+        "display_name": "Nonlinear Gradient Correction",
+        "description": "Boolean stating if the image saved has been corrected for gradient\nnonlinearities by the scanner sequence.\n",
+        "type": "boolean"
+      },
+      "NumberOfVolumesDiscardedByScanner": {
+        "name": "NumberOfVolumesDiscardedByScanner",
+        "display_name": "Number Of Volumes Discarded By Scanner",
+        "description": "Number of volumes (\"dummy scans\") discarded by the scanner\n(as opposed to those discarded by the user post hoc)\nbefore saving the imaging file.\nFor example, a sequence that automatically discards the first 4 volumes\nbefore saving would have this field as 4.\nA sequence that does not discard dummy scans would have this set to 0.\nPlease note that the onsets recorded in the `events.tsv` file should always\nrefer to the beginning of the acquisition of the first volume in the\ncorresponding imaging file - independent of the value of\n`\"NumberOfVolumesDiscardedByScanner\"` field.\n",
+        "type": "integer",
+        "minimum": 0
+      },
+      "NumberOfVolumesDiscardedByUser": {
+        "name": "NumberOfVolumesDiscardedByUser",
+        "display_name": "Number Of Volumes Discarded By User",
+        "description": "Number of volumes (\"dummy scans\") discarded by the user before including the\nfile in the dataset.\nIf possible, including all of the volumes is strongly recommended.\nPlease note that the onsets recorded in the `events.tsv` file should always\nrefer to the beginning of the acquisition of the first volume in the\ncorresponding imaging file - independent of the value of\n`\"NumberOfVolumesDiscardedByUser\"` field.\n",
+        "type": "integer",
+        "minimum": 0
+      },
+      "NumberShots": {
+        "name": "NumberShots",
+        "display_name": "Number Shots",
+        "description": "The number of RF excitations needed to reconstruct a slice or volume\n(may be referred to as partition).\nPlease mind that this is not the same as Echo Train Length which denotes the\nnumber of k-space lines collected after excitation in a multi-echo readout.\nThe data type array is applicable for specifying this parameter before and\nafter the k-space center is sampled.\nPlease see\n[`\"NumberShots\"` metadata field]\\\n(SPEC_ROOT/appendices/qmri.md#numbershots-metadata-field)\nin the qMRI appendix for corresponding calculations.\n",
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          }
+        ]
+      },
+      "NumericalAperture": {
+        "name": "NumericalAperture",
+        "display_name": "Numerical Aperture",
+        "description": "Lens numerical aperture (for example: `1.4`). If the file format is OME-TIFF,\nthe value MUST be consistent with the `LensNA` OME metadata field.\n",
+        "type": "number",
+        "exclusiveMinimum": 0
+      },
+      "OperatingSystem": {
+        "name": "OperatingSystem",
+        "display_name": "Operating System",
+        "description": "Operating system used to run the stimuli presentation software\n(for formatting recommendations, see examples below this table).\n",
+        "type": "string"
+      },
+      "OtherAcquisitionParameters": {
+        "name": "OtherAcquisitionParameters",
+        "display_name": "Other Acquisition Parameters",
+        "description": "Description of other relevant image acquisition parameters.\n",
+        "type": "string"
+      },
+      "PASLType": {
+        "name": "PASLType",
+        "display_name": "PASL Type",
+        "description": "Type of the labeling pulse of the `PASL` labeling,\nfor example `\"FAIR\"`, `\"EPISTAR\"`, or `\"PICORE\"`.\n",
+        "type": "string"
+      },
+      "PCASLType": {
+        "name": "PCASLType",
+        "display_name": "PCASL Type",
+        "description": "The type of gradient pulses used in the `control` condition.\n",
+        "type": "string",
+        "enum": [
+          "balanced",
+          "unbalanced"
+        ]
+      },
+      "ParallelAcquisitionTechnique": {
+        "name": "ParallelAcquisitionTechnique",
+        "display_name": "Parallel Acquisition Technique",
+        "description": "The type of parallel imaging used (for example `\"GRAPPA\"`, `\"SENSE\"`).\nCorresponds to DICOM Tag 0018, 9078 `Parallel Acquisition Technique`.\n",
+        "type": "string"
+      },
+      "ParallelReductionFactorInPlane": {
+        "name": "ParallelReductionFactorInPlane",
+        "display_name": "Parallel Reduction Factor In Plane",
+        "description": "The parallel imaging (for instance, GRAPPA) factor.\nUse the denominator of the fraction of k-space encoded for each slice.\nFor example, 2 means half of k-space is encoded.\nCorresponds to DICOM Tag 0018, 9069 `Parallel Reduction Factor In-plane`.\n",
+        "type": "number"
+      },
+      "PartialFourier": {
+        "name": "PartialFourier",
+        "display_name": "Partial Fourier",
+        "description": "The fraction of partial Fourier information collected.\nCorresponds to DICOM Tag 0018, 9081 `Partial Fourier`.\n",
+        "type": "number"
+      },
+      "PartialFourierDirection": {
+        "name": "PartialFourierDirection",
+        "display_name": "Partial Fourier Direction",
+        "description": "The direction where only partial Fourier information was collected.\nCorresponds to DICOM Tag 0018, 9036 `Partial Fourier Direction`.\n",
+        "type": "string"
+      },
+      "PharmaceuticalDoseAmount": {
+        "name": "PharmaceuticalDoseAmount",
+        "display_name": "Pharmaceutical Dose Amount",
+        "description": "Dose amount of pharmaceutical coadministered with tracer.\n",
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          }
+        ]
+      },
+      "PharmaceuticalDoseRegimen": {
+        "name": "PharmaceuticalDoseRegimen",
+        "display_name": "Pharmaceutical Dose Regimen",
+        "description": "Details of the pharmaceutical dose regimen.\nEither adequate description or short-code relating to regimen documented\nelsewhere (for example, `\"single oral bolus\"`).\n",
+        "type": "string"
+      },
+      "PharmaceuticalDoseTime": {
+        "name": "PharmaceuticalDoseTime",
+        "display_name": "Pharmaceutical Dose Time",
+        "description": "Time of administration of pharmaceutical dose, relative to time zero.\nFor an infusion, this should be a vector with two elements specifying the\nstart and end of the infusion period. For more complex dose regimens,\nthe regimen description should be complete enough to enable unambiguous\ninterpretation of `\"PharmaceuticalDoseTime\"`.\nUnit format of the specified pharmaceutical dose time MUST be seconds.\n",
+        "anyOf": [
+          {
+            "type": "number",
+            "unit": "s"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "unit": "s"
+            }
+          }
+        ]
+      },
+      "PharmaceuticalDoseUnits": {
+        "name": "PharmaceuticalDoseUnits",
+        "display_name": "Pharmaceutical Dose Units",
+        "description": "Unit format relating to pharmaceutical dose\n(for example, `\"mg\"` or `\"mg/kg\"`).\n",
+        "type": "string",
+        "format": "unit"
+      },
+      "PharmaceuticalName": {
+        "name": "PharmaceuticalName",
+        "display_name": "Pharmaceutical Name",
+        "description": "Name of pharmaceutical coadministered with tracer.\n",
+        "type": "string"
+      },
+      "PhaseEncodingDirection": {
+        "name": "PhaseEncodingDirection",
+        "display_name": "Phase Encoding Direction",
+        "description": "The letters `i`, `j`, `k` correspond to the first, second and third axis of\nthe data in the NIFTI file.\nThe polarity of the phase encoding is assumed to go from zero index to\nmaximum index unless `-` sign is present\n(then the order is reversed - starting from the highest index instead of\nzero).\n`PhaseEncodingDirection` is defined as the direction along which phase is was\nmodulated which may result in visible distortions.\nNote that this is not the same as the DICOM term\n`InPlanePhaseEncodingDirection` which can have `ROW` or `COL` values.\n",
+        "type": "string",
+        "enum": [
+          "i",
+          "j",
+          "k",
+          "i-",
+          "j-",
+          "k-"
+        ]
+      },
+      "PhotoDescription": {
+        "name": "PhotoDescription",
+        "display_name": "Photo Description",
+        "description": "Description of the photo.\n",
+        "type": "string"
+      },
+      "PixelSize": {
+        "name": "PixelSize",
+        "display_name": "Pixel Size",
+        "description": "A 2- or 3-number array of the physical size of a pixel, either `[PixelSizeX, PixelSizeY]`\nor `[PixelSizeX, PixelSizeY, PixelSizeZ]`, where X is the width, Y the height and Z the\ndepth.\nIf the file format is OME-TIFF, these values need to be consistent with `PhysicalSizeX`,\n`PhysicalSizeY` and `PhysicalSizeZ` OME metadata fields, after converting in\n`PixelSizeUnits` according to `PhysicalSizeXunit`, `PhysicalSizeYunit` and\n`PhysicalSizeZunit` OME fields.\n",
+        "type": "array",
+        "minItems": 2,
+        "maxItems": 3,
+        "items": {
+          "type": "number",
+          "minimum": 0
+        }
+      },
+      "PixelSizeUnits": {
+        "name": "PixelSizeUnits",
+        "display_name": "Pixel Size Units",
+        "description": "Unit format of the specified `\"PixelSize\"`. MUST be one of: `\"mm\"` (millimeter), `\"um\"`\n(micrometer) or `\"nm\"` (nanometer).\n",
+        "type": "string",
+        "enum": [
+          "mm",
+          "um",
+          "nm"
+        ]
+      },
+      "PlasmaAvail": {
+        "name": "PlasmaAvail",
+        "display_name": "Plasma Avail",
+        "description": "Boolean that specifies if plasma measurements are available.\n",
+        "type": "boolean"
+      },
+      "PlasmaFreeFraction": {
+        "name": "PlasmaFreeFraction",
+        "display_name": "Plasma Free Fraction",
+        "description": "Measured free fraction in plasma, meaning the concentration of free compound\nin plasma divided by total concentration of compound in plasma\n(Units: 0-100%).\n",
+        "type": "number",
+        "minimum": 0,
+        "maximum": 100
+      },
+      "PlasmaFreeFractionMethod": {
+        "name": "PlasmaFreeFractionMethod",
+        "display_name": "Plasma Free Fraction Method",
+        "description": "Method used to estimate free fraction.\n",
+        "type": "string"
+      },
+      "PostLabelingDelay": {
+        "name": "PostLabelingDelay",
+        "display_name": "Post Labeling Delay",
+        "description": "This is the postlabeling delay (PLD) time, in seconds, after the end of the\nlabeling (for `\"CASL\"` or `\"PCASL\"`) or middle of the labeling pulse\n(for `\"PASL\"`) until the middle of the excitation pulse applied to the\nimaging slab (for 3D acquisition) or first slice (for 2D acquisition).\nCan be a number (for a single-PLD time series) or an array of numbers\n(for multi-PLD and Look-Locker).\nIn the latter case, the array of numbers contains the PLD of each volume,\nnamely each `control` and `label`, in the acquisition order.\nAny image within the time-series without a PLD, for example an `m0scan`,\nis indicated by a zero.\nBased on DICOM Tags 0018, 9079 `Inversion Times` and 0018, 0082\n`InversionTime`.\n",
+        "anyOf": [
+          {
+            "type": "number",
+            "exclusiveMinimum": 0,
+            "unit": "s"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "exclusiveMinimum": 0,
+              "unit": "s"
+            }
+          }
+        ]
+      },
+      "PowerLineFrequency": {
+        "name": "PowerLineFrequency",
+        "display_name": "Power Line Frequency",
+        "description": "Frequency (in Hz) of the power grid at the geographical location of the\ninstrument (for example, `50` or `60`).\n",
+        "anyOf": [
+          {
+            "type": "number",
+            "exclusiveMinimum": 0,
+            "unit": "Hz"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "n/a"
+            ]
+          }
+        ]
+      },
+      "PromptRate": {
+        "name": "PromptRate",
+        "display_name": "Prompt Rate",
+        "description": "Prompt rate for each frame (same units as `Units`, for example, `\"Bq/mL\"`).\n",
+        "type": "array",
+        "items": {
+          "type": "number"
+        }
+      },
+      "PulseSequenceDetails": {
+        "name": "PulseSequenceDetails",
+        "display_name": "Pulse Sequence Details",
+        "description": "Information beyond pulse sequence type that identifies the specific pulse\nsequence used (for example,\n`\"Standard Siemens Sequence distributed with the VB17 software\"`,\n`\"Siemens WIP ### version #.##,\"` or\n`\"Sequence written by X using a version compiled on MM/DD/YYYY\"`).\n",
+        "type": "string"
+      },
+      "PulseSequenceType": {
+        "name": "PulseSequenceType",
+        "display_name": "Pulse Sequence Type",
+        "description": "A general description of the pulse sequence used for the scan\n(for example, `\"MPRAGE\"`, `\"Gradient Echo EPI\"`, `\"Spin Echo EPI\"`,\n`\"Multiband gradient echo EPI\"`).\n",
+        "type": "string"
+      },
+      "Purity": {
+        "name": "Purity",
+        "display_name": "Purity",
+        "description": "Purity of the radiolabeled compound (between 0 and 100%).\n",
+        "type": "number",
+        "minimum": 0,
+        "maximum": 100
+      },
+      "RandomRate": {
+        "name": "RandomRate",
+        "display_name": "Random Rate",
+        "description": "Random rate for each frame (same units as `\"Units\"`, for example, `\"Bq/mL\"`).\n",
+        "type": "array",
+        "items": {
+          "type": "number"
+        }
+      },
+      "RawSources": {
+        "name": "RawSources",
+        "display_name": "Raw Sources",
+        "description": "A list of paths relative to dataset root pointing to the BIDS-Raw file(s)\nthat were used in the creation of this derivative.\nThis field is DEPRECATED, and this metadata SHOULD be recorded in the\n`Sources` field using [BIDS URIs](SPEC_ROOT/02-common-principles.md#bids-uri)\nto distinguish sources from different datasets.\n",
+        "type": "array",
+        "items": {
+          "type": "string",
+          "format": "dataset_relative"
+        }
+      },
+      "ReceiveCoilActiveElements": {
+        "name": "ReceiveCoilActiveElements",
+        "display_name": "Receive Coil Active Elements",
+        "description": "Information describing the active/selected elements of the receiver coil.\nThis does not correspond to a tag in the DICOM ontology.\nThe vendor-defined terminology for active coil elements can go in this field.\n",
+        "type": "string"
+      },
+      "ReceiveCoilName": {
+        "name": "ReceiveCoilName",
+        "display_name": "Receive Coil Name",
+        "description": "Information describing the receiver coil.\nCorresponds to DICOM Tag 0018, 1250 `Receive Coil Name`,\nalthough not all vendors populate that DICOM Tag,\nin which case this field can be derived from an appropriate\nprivate DICOM field.\n",
+        "type": "string"
+      },
+      "ReconFilterSize": {
+        "name": "ReconFilterSize",
+        "display_name": "Recon Filter Size",
+        "description": "Kernel size of post-recon filter (FWHM) in default units `\"mm\"`.\n",
+        "anyOf": [
+          {
+            "type": "number",
+            "unit": "mm"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "unit": "mm"
+            }
+          }
+        ]
+      },
+      "ReconFilterType": {
+        "name": "ReconFilterType",
+        "display_name": "Recon Filter Type",
+        "description": "Type of post-recon smoothing (for example, `[\"Shepp\"]`).\n",
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "ReconMethodImplementationVersion": {
+        "name": "ReconMethodImplementationVersion",
+        "display_name": "Recon Method Implementation Version",
+        "description": "Identification for the software used, such as name and version.\n",
+        "type": "string"
+      },
+      "ReconMethodName": {
+        "name": "ReconMethodName",
+        "display_name": "Recon Method Name",
+        "description": "Reconstruction method or algorithm (for example, `\"3d-op-osem\"`).\n",
+        "type": "string"
+      },
+      "ReconMethodParameterLabels": {
+        "name": "ReconMethodParameterLabels",
+        "display_name": "Recon Method Parameter Labels",
+        "description": "Names of reconstruction parameters (for example, `[\"subsets\", \"iterations\"]`).\n",
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "ReconMethodParameterUnits": {
+        "name": "ReconMethodParameterUnits",
+        "display_name": "Recon Method Parameter Units",
+        "description": "Unit of reconstruction parameters (for example, `[\"none\", \"none\"]`).\n",
+        "type": "array",
+        "items": {
+          "type": "string",
+          "format": "unit"
+        }
+      },
+      "ReconMethodParameterValues": {
+        "name": "ReconMethodParameterValues",
+        "display_name": "Recon Method Parameter Values",
+        "description": "Values of reconstruction parameters (for example, `[21, 3]`).\n",
+        "type": "array",
+        "items": {
+          "type": "number"
+        }
+      },
+      "RecordingDuration": {
+        "name": "RecordingDuration",
+        "display_name": "Recording Duration",
+        "description": "Length of the recording in seconds (for example, `3600`).\n",
+        "type": "number",
+        "unit": "s"
+      },
+      "RecordingType": {
+        "name": "RecordingType",
+        "display_name": "Recording Type",
+        "description": "Defines whether the recording is `\"continuous\"`, `\"discontinuous\"`, or\n`\"epoched\"`, where `\"epoched\"` is limited to time windows about events of\ninterest (for example, stimulus presentations or subject responses).\n",
+        "type": "string",
+        "enum": [
+          "continuous",
+          "epoched",
+          "discontinuous"
+        ]
+      },
+      "ReferencesAndLinks": {
+        "name": "ReferencesAndLinks",
+        "display_name": "References And Links",
+        "description": "List of references to publications that contain information on the dataset.\nA reference may be textual or a\n[URI](SPEC_ROOT/02-common-principles.md#uniform-resource-indicator).\n",
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "RepetitionTime": {
+        "name": "RepetitionTime",
+        "display_name": "Repetition Time",
+        "description": "The time in seconds between the beginning of an acquisition of one volume\nand the beginning of acquisition of the volume following it (TR).\nWhen used in the context of functional acquisitions this parameter best\ncorresponds to\n[DICOM Tag 0020, 0110](http://dicomlookup.com/lookup.asp?sw=Tnumber&q=(0020,0110)):\nthe \"time delta between images in a\ndynamic of functional set of images\" but may also be found in\n[DICOM Tag 0018, 0080](http://dicomlookup.com/lookup.asp?sw=Tnumber&q=(0018,0080)):\n\"the period of time in msec between the beginning\nof a pulse sequence and the beginning of the succeeding\n(essentially identical) pulse sequence\".\nThis definition includes time between scans (when no data has been acquired)\nin case of sparse acquisition schemes.\nThis value MUST be consistent with the 'pixdim[4]' field (after accounting\nfor units stored in 'xyzt_units' field) in the NIfTI header.\nThis field is mutually exclusive with VolumeTiming.\n",
+        "type": "number",
+        "exclusiveMinimum": 0,
+        "unit": "s"
+      },
+      "RepetitionTimeExcitation": {
+        "name": "RepetitionTimeExcitation",
+        "display_name": "Repetition Time Excitation",
+        "description": "The interval, in seconds, between two successive excitations.\n[DICOM Tag 0018, 0080](http://dicomlookup.com/lookup.asp?sw=Tnumber&q=(0018,0080))\nbest refers to this parameter.\nThis field may be used together with the `\"RepetitionTimePreparation\"` for\ncertain use cases, such as\n[MP2RAGE](https://doi.org/10.1016/j.neuroimage.2009.10.002).\nUse `RepetitionTimeExcitation` (in combination with\n`\"RepetitionTimePreparation\"` if needed) for anatomy imaging data rather than\n`\"RepetitionTime\"` as it is already defined as the amount of time that it takes\nto acquire a single volume in the\n[task imaging data](SPEC_ROOT/04-modality-specific-files/01-magnetic-resonance-\\\nimaging-data.md#task-including-resting-state-imaging-data)\nsection.\n",
+        "type": "number",
+        "minimum": 0,
+        "unit": "s"
+      },
+      "RepetitionTimePreparation": {
+        "name": "RepetitionTimePreparation",
+        "display_name": "Repetition Time Preparation",
+        "description": "The interval, in seconds, that it takes a preparation pulse block to\nre-appear at the beginning of the succeeding (essentially identical) pulse\nsequence block.\nThe data type number may apply to files from any MRI modality concerned with\na single value for this field.\nThe data type array provides a value for each volume in a 4D dataset and\nshould only be used when the volume timing is critical for interpretation of\nthe data, such as in\n[ASL](SPEC_ROOT/04-modality-specific-files/01-magnetic-resonance-imaging-data.md\\\n#arterial-spin-labeling-perfusion-data).\n",
+        "anyOf": [
+          {
+            "type": "number",
+            "minimum": 0,
+            "unit": "s"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "minimum": 0,
+              "unit": "s"
+            }
+          }
+        ]
+      },
+      "Resolution": {
+        "name": "Resolution",
+        "display_name": "Resolution",
+        "description": "Specifies the interpretation of the resolution keyword.\nIf an object is used, then the keys should be values for the `res` entity\nand values should be descriptions of those `res` values.\n",
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "SEEGChannelCount": {
+        "name": "SEEGChannelCount",
+        "display_name": "SEEG Channel Count",
+        "description": "Number of SEEG channels.\n",
+        "type": "integer",
+        "minimum": 0
+      },
+      "SampleEmbedding": {
+        "name": "SampleEmbedding",
+        "display_name": "Sample Embedding",
+        "description": "Description of the tissue sample embedding (for example: `\"Epoxy resin\"`).\n",
+        "type": "string"
+      },
+      "SampleEnvironment": {
+        "name": "SampleEnvironment",
+        "display_name": "Sample Environment",
+        "description": "Environment in which the sample was imaged. MUST be one of: `\"in vivo\"`, `\"ex vivo\"`\nor `\"in vitro\"`.\n",
+        "type": "string",
+        "enum": [
+          "in vivo",
+          "ex vivo",
+          "in vitro"
+        ]
+      },
+      "SampleExtractionInstitution": {
+        "name": "SampleExtractionInstitution",
+        "display_name": "Sample Extraction Institution",
+        "description": "The name of the institution in charge of the extraction of the sample,\nif different from the institution in charge of the equipment that produced the image.\n",
+        "type": "string"
+      },
+      "SampleExtractionProtocol": {
+        "name": "SampleExtractionProtocol",
+        "display_name": "Sample Extraction Protocol",
+        "description": "Description of the sample extraction protocol or\n[URI](SPEC_ROOT/02-common-principles.md#uniform-resource-indicator)\n(for example from [protocols.io](https://www.protocols.io/)).\n",
+        "type": "string"
+      },
+      "SampleFixation": {
+        "name": "SampleFixation",
+        "display_name": "Sample Fixation",
+        "description": "Description of the tissue sample fixation\n(for example: `\"4% paraformaldehyde, 2% glutaraldehyde\"`).\n",
+        "type": "string"
+      },
+      "SampleOrigin": {
+        "name": "SampleOrigin",
+        "display_name": "Sample Origin",
+        "description": "Describes from which tissue the genetic information was extracted.\n",
+        "type": "string",
+        "enum": [
+          "blood",
+          "saliva",
+          "brain",
+          "csf",
+          "breast milk",
+          "bile",
+          "amniotic fluid",
+          "other biospecimen"
+        ]
+      },
+      "SamplePrimaryAntibody": {
+        "name": "SamplePrimaryAntibody",
+        "display_name": "Sample Primary Antibody",
+        "description": "Description(s) of the primary antibody used for immunostaining.\nEither an [RRID](https://scicrunch.org/resources) or the name, supplier and catalogue\nnumber of a commercial antibody.\nFor non-commercial antibodies either an [RRID](https://scicrunch.org/resources) or the\nhost-animal and immunogen used (for examples: `\"RRID:AB_2122563\"` or\n`\"Rabbit anti-Human HTR5A Polyclonal Antibody, Invitrogen, Catalog # PA1-2453\"`).\nMAY be an array of strings if different antibodies are used in each channel of the file.\n",
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "SampleSecondaryAntibody": {
+        "name": "SampleSecondaryAntibody",
+        "display_name": "Sample Secondary Antibody",
+        "description": "Description(s) of the secondary antibody used for immunostaining.\nEither an [RRID](https://scicrunch.org/resources) or the name, supplier and catalogue\nnumber of a commercial antibody.\nFor non-commercial antibodies either an [RRID](https://scicrunch.org/resources) or the\nhost-animal and immunogen used (for examples: `\"RRID:AB_228322\"` or\n`\"Goat anti-Mouse IgM Secondary Antibody, Invitrogen, Catalog # 31172\"`).\nMAY be an array of strings if different antibodies are used in each channel of the file.\n",
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "SampleStaining": {
+        "name": "SampleStaining",
+        "display_name": "Sample Staining",
+        "description": "Description(s) of the tissue sample staining (for example: `\"Osmium\"`).\nMAY be an array of strings if different stains are used in each channel of the file\n(for example: `[\"LFB\", \"PLP\"]`).\n",
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "SamplingFrequency": {
+        "name": "SamplingFrequency",
+        "display_name": "Sampling Frequency",
+        "description": "Sampling frequency (in Hz) of all the data in the recording,\nregardless of their type (for example, `2400`).\n",
+        "type": "number",
+        "unit": "Hz"
+      },
+      "SamplingFrequency__nirs": {
+        "name": "SamplingFrequency",
+        "display_name": "Sampling Frequency",
+        "description": "Sampling frequency (in Hz) of all the data in the recording,\nregardless of their type (for example, `2400`).\n",
+        "anyOf": [
+          {
+            "type": "number",
+            "unit": "Hz"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "n/a"
+            ]
+          }
+        ]
+      },
+      "ScaleFactor": {
+        "name": "ScaleFactor",
+        "display_name": "Scale Factor",
+        "description": "Scale factor for each frame. This field MUST be defined if the imaging data (`.nii[.gz]`) are scaled.\nIf this field is not defined, then it is assumed that the scaling factor is 1. Defining this field\nwhen the scaling factor is 1 is RECOMMENDED, for the sake of clarity.\n",
+        "type": "array",
+        "items": {
+          "type": "number"
+        }
+      },
+      "ScanDate": {
+        "name": "ScanDate",
+        "display_name": "Scan Date",
+        "description": "Date of scan in the format `\"YYYY-MM-DD[Z]\"`.\nThis field is DEPRECATED, and this metadata SHOULD be recorded in the `acq_time` column of the\ncorresponding [Scans file](SPEC_ROOT/03-modality-agnostic-files.md#scans-file).\n",
+        "type": "string",
+        "format": "date"
+      },
+      "ScanOptions": {
+        "name": "ScanOptions",
+        "display_name": "Scan Options",
+        "description": "Parameters of ScanningSequence.\nCorresponds to DICOM Tag 0018, 0022 `Scan Options`.\n",
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "ScanStart": {
+        "name": "ScanStart",
+        "display_name": "Scan Start",
+        "description": "Time of start of scan with respect to `TimeZero` in the default unit seconds.\n",
+        "type": "number",
+        "unit": "s"
+      },
+      "ScanningSequence": {
+        "name": "ScanningSequence",
+        "display_name": "Scanning Sequence",
+        "description": "Description of the type of data acquired.\nCorresponds to DICOM Tag 0018, 0020 `Scanning Sequence`.\n",
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "ScatterFraction": {
+        "name": "ScatterFraction",
+        "display_name": "Scatter Fraction",
+        "description": "Scatter fraction for each frame (Units: 0-100%).\n",
+        "type": "array",
+        "items": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100
+        }
+      },
+      "SequenceName": {
+        "name": "SequenceName",
+        "display_name": "Sequence Name",
+        "description": "Manufacturer's designation of the sequence name.\nCorresponds to DICOM Tag 0018, 0024 `Sequence Name`.\n",
+        "type": "string"
+      },
+      "SequenceVariant": {
+        "name": "SequenceVariant",
+        "display_name": "Sequence Variant",
+        "description": "Variant of the ScanningSequence.\nCorresponds to DICOM Tag 0018, 0021 `Sequence Variant`.\n",
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "ShortChannelCount": {
+        "name": "ShortChannelCount",
+        "display_name": "Short Channel Count",
+        "description": "The number of short channels. 0 indicates no short channels.\n",
+        "type": "integer",
+        "minimum": 0
+      },
+      "SinglesRate": {
+        "name": "SinglesRate",
+        "display_name": "Singles Rate",
+        "description": "Singles rate for each frame (same units as `Units`, for example, `\"Bq/mL\"`).\n",
+        "type": "array",
+        "items": {
+          "type": "number"
+        }
+      },
+      "SkullStripped": {
+        "name": "SkullStripped",
+        "display_name": "Skull Stripped",
+        "description": "Whether the volume was skull stripped (non-brain voxels set to zero) or not.\n",
+        "type": "boolean"
+      },
+      "SliceEncodingDirection": {
+        "name": "SliceEncodingDirection",
+        "display_name": "Slice Encoding Direction",
+        "description": "The axis of the NIfTI data along which slices were acquired,\nand the direction in which `\"SliceTiming\"` is defined with respect to.\n`i`, `j`, `k` identifiers correspond to the first, second and third axis of\nthe data in the NIfTI file.\nA `-` sign indicates that the contents of `\"SliceTiming\"` are defined in\nreverse order - that is, the first entry corresponds to the slice with the\nlargest index, and the final entry corresponds to slice index zero.\nWhen present, the axis defined by `\"SliceEncodingDirection\"` needs to be\nconsistent with the `slice_dim` field in the NIfTI header.\nWhen absent, the entries in `\"SliceTiming\"` must be in the order of increasing\nslice index as defined by the NIfTI header.\n",
+        "type": "string",
+        "enum": [
+          "i",
+          "j",
+          "k",
+          "i-",
+          "j-",
+          "k-"
+        ]
+      },
+      "SliceThickness": {
+        "name": "SliceThickness",
+        "display_name": "Slice Thickness",
+        "description": "Slice thickness of the tissue sample in the unit micrometers (`\"um\"`) (for example: `5`).\n",
+        "type": "number",
+        "unit": "um",
+        "exclusiveMinimum": 0
+      },
+      "SliceTiming": {
+        "name": "SliceTiming",
+        "display_name": "Slice Timing",
+        "description": "The time at which each slice was acquired within each volume (frame) of the\nacquisition.\nSlice timing is not slice order -- rather, it is a list of times containing\nthe time (in seconds) of each slice acquisition in relation to the beginning\nof volume acquisition.\nThe list goes through the slices along the slice axis in the slice encoding\ndimension (see below).\nNote that to ensure the proper interpretation of the `\"SliceTiming\"` field,\nit is important to check if the OPTIONAL `SliceEncodingDirection` exists.\nIn particular, if `\"SliceEncodingDirection\"` is negative,\nthe entries in `\"SliceTiming\"` are defined in reverse order with respect to the\nslice axis, such that the final entry in the `\"SliceTiming\"` list is the time\nof acquisition of slice 0. Without this parameter slice time correction will\nnot be possible.\n",
+        "type": "array",
+        "items": {
+          "type": "number",
+          "minimum": 0,
+          "unit": "s"
+        }
+      },
+      "SoftwareFilters": {
+        "name": "SoftwareFilters",
+        "display_name": "Software Filters",
+        "description": "[Object](https://www.json.org/json-en.html)\nof temporal software filters applied, or `\"n/a\"` if the data is\nnot available.\nEach key-value pair in the JSON object is a name of the filter and an object\nin which its parameters are defined as key-value pairs\n(for example, `{\"Anti-aliasing filter\":\n{\"half-amplitude cutoff (Hz)\": 500, \"Roll-off\": \"6dB/Octave\"}}`).\n",
+        "anyOf": [
+          {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object"
+            }
+          },
+          {
+            "type": "string",
+            "enum": [
+              "n/a"
+            ]
+          }
+        ]
+      },
+      "SoftwareName": {
+        "name": "SoftwareName",
+        "display_name": "Software Name",
+        "description": "Name of the software that was used to present the stimuli.\n",
+        "type": "string"
+      },
+      "SoftwareRRID": {
+        "name": "SoftwareRRID",
+        "display_name": "SoftwareRRID",
+        "description": "[Research Resource Identifier](https://scicrunch.org/resources) of the\nsoftware that was used to present the stimuli.\nExamples: The RRID for Psychtoolbox is 'SCR_002881',\nand that of PsychoPy is 'SCR_006571'.\n",
+        "type": "string",
+        "format": "rrid"
+      },
+      "SoftwareVersion": {
+        "name": "SoftwareVersion",
+        "display_name": "Software Version",
+        "description": "Version of the software that was used to present the stimuli.\n",
+        "type": "string"
+      },
+      "SoftwareVersions": {
+        "name": "SoftwareVersions",
+        "display_name": "Software Versions",
+        "description": "Manufacturer's designation of software version of the equipment that produced\nthe measurements.\n",
+        "type": "string"
+      },
+      "SourceDatasets": {
+        "name": "SourceDatasets",
+        "display_name": "Source Datasets",
+        "description": "Used to specify the locations and relevant attributes of all source datasets.\nValid keys in each object include `\"URL\"`, `\"DOI\"` (see\n[URI](SPEC_ROOT/02-common-principles.md#uniform-resource-indicator)), and\n`\"Version\"` with\n[string](https://www.w3schools.com/js/js_json_datatypes.asp)\nvalues.\n",
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "URL": {
+              "type": "string",
+              "format": "uri"
+            },
+            "DOI": {
+              "type": "string"
+            },
+            "Version": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "Sources": {
+        "name": "Sources",
+        "display_name": "Sources",
+        "description": "A list of files with the paths specified using\n[BIDS URIs](SPEC_ROOT/02-common-principles.md#bids-uri);\nthese files were directly used in the creation of this derivative data file.\nFor example, if a derivative A is used in the creation of another\nderivative B, which is in turn used to generate C in a chain of A->B->C,\nC should only list B in `\"Sources\"`, and B should only list A in `\"Sources\"`.\nHowever, in case both X and Y are directly used in the creation of Z,\nthen Z should list X and Y in `\"Sources\"`,\nregardless of whether X was used to generate Y.\nUsing paths specified relative to the dataset root is\n[DEPRECATED](SPEC_ROOT/02-common-principles.md#definitions).\n",
+        "type": "array",
+        "items": {
+          "type": "string",
+          "format": "dataset_relative"
+        }
+      },
+      "SourceType": {
+        "name": "SourceType",
+        "display_name": "Source Type",
+        "description": "Type of source. Preferably a specific model/part number is supplied.\nThis is a freeform description, but the following keywords are suggested:\n`\"LED\"`, `\"LASER\"`, `\"VCSEL\"`. If individual channels have different SourceType,\nthen the field here should be specified as \"mixed\"\nand this column should be included in optodes.tsv.\n",
+        "type": "string"
+      },
+      "SpatialReference": {
+        "name": "SpatialReference",
+        "display_name": "Spatial Reference",
+        "description": "For images with a single reference, the value MUST be a single string.\nFor images with multiple references, such as surface and volume references,\na JSON object MUST be used.\n",
+        "anyOf": [
+          {
+            "type": "string",
+            "enum": [
+              "orig"
+            ]
+          },
+          {
+            "type": "string",
+            "format": "uri"
+          },
+          {
+            "type": "string",
+            "format": "dataset_relative"
+          },
+          {
+            "type": "object",
+            "additionalProperties": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "orig"
+                  ]
+                },
+                {
+                  "type": "string",
+                  "format": "uri"
+                },
+                {
+                  "type": "string",
+                  "format": "dataset_relative"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "SpecificRadioactivity": {
+        "name": "SpecificRadioactivity",
+        "display_name": "Specific Radioactivity",
+        "description": "Specific activity of compound injected.\n**Note this is not required for an FDG acquisition, since it is not available,\nand SHOULD be set to `\"n/a\"`**.\n",
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "n/a"
+            ]
+          }
+        ]
+      },
+      "SpecificRadioactivityMeasTime": {
+        "name": "SpecificRadioactivityMeasTime",
+        "display_name": "Specific Radioactivity Measurement Time",
+        "description": "Time to which specific radioactivity measurement above applies in the default\nunit `\"hh:mm:ss\"`.\n",
+        "type": "string",
+        "format": "time"
+      },
+      "SpecificRadioactivityUnits": {
+        "name": "SpecificRadioactivityUnits",
+        "display_name": "Specific Radioactivity Units",
+        "description": "Unit format of specified specific radioactivity (for example, `\"Bq/g\"`).\n**Note this is not required for an FDG acquisition, since it is not available,\nand SHOULD be set to `\"n/a\"`**.\n",
+        "anyOf": [
+          {
+            "type": "string",
+            "format": "unit"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "n/a"
+            ]
+          }
+        ]
+      },
+      "SpoilingGradientDuration": {
+        "name": "SpoilingGradientDuration",
+        "display_name": "Spoiling Gradient Duration",
+        "description": "The duration of the spoiler gradient lobe in seconds.\nThe duration of a trapezoidal lobe is defined as the summation of ramp-up\nand plateau times.\n",
+        "type": "number",
+        "unit": "s"
+      },
+      "SpoilingGradientMoment": {
+        "name": "SpoilingGradientMoment",
+        "display_name": "Spoiling Gradient Moment",
+        "description": "Zeroth moment of the spoiler gradient lobe in\nmillitesla times second per meter (mT.s/m).\n",
+        "type": "number",
+        "unit": "mT.s/m"
+      },
+      "SpoilingRFPhaseIncrement": {
+        "name": "SpoilingRFPhaseIncrement",
+        "display_name": "Spoiling RF Phase Increment",
+        "description": "The amount of incrementation described in degrees,\nwhich is applied to the phase of the excitation pulse at each TR period for\nachieving RF spoiling.\n",
+        "type": "number",
+        "unit": "degrees"
+      },
+      "SpoilingState": {
+        "name": "SpoilingState",
+        "display_name": "Spoiling State",
+        "description": "Boolean stating whether the pulse sequence uses any type of spoiling\nstrategy to suppress residual transverse magnetization.\n",
+        "type": "boolean"
+      },
+      "SpoilingType": {
+        "name": "SpoilingType",
+        "display_name": "Spoiling Type",
+        "description": "Specifies which spoiling method(s) are used by a spoiled sequence.\n",
+        "type": "string",
+        "enum": [
+          "RF",
+          "GRADIENT",
+          "COMBINED"
+        ]
+      },
+      "StartTime": {
+        "name": "StartTime",
+        "display_name": "Start Time",
+        "description": "Start time in seconds in relation to the start of acquisition of the first\ndata sample in the corresponding neural dataset (negative values are allowed).\n",
+        "type": "number",
+        "unit": "s"
+      },
+      "StationName": {
+        "name": "StationName",
+        "display_name": "Station Name",
+        "description": "Institution defined name of the machine that produced the measurements.\n",
+        "type": "string"
+      },
+      "StimulusPresentation": {
+        "name": "StimulusPresentation",
+        "display_name": "Stimulus Presentation",
+        "description": "Object containing key-value pairs related to the software used to present\nthe stimuli during the experiment, specifically:\n`\"OperatingSystem\"`, `\"SoftwareName\"`, `\"SoftwareRRID\"`, `\"SoftwareVersion\"` and\n`\"Code\"`.\nSee table below for more information.\n",
+        "type": "object",
+        "properties": {
+          "OperatingSystem": {
+            "name": "OperatingSystem",
+            "display_name": "Operating System",
+            "description": "Operating system used to run the stimuli presentation software\n(for formatting recommendations, see examples below this table).\n",
+            "type": "string"
+          },
+          "SoftwareName": {
+            "name": "SoftwareName",
+            "display_name": "Software Name",
+            "description": "Name of the software that was used to present the stimuli.\n",
+            "type": "string"
+          },
+          "SoftwareRRID": {
+            "name": "SoftwareRRID",
+            "display_name": "SoftwareRRID",
+            "description": "[Research Resource Identifier](https://scicrunch.org/resources) of the\nsoftware that was used to present the stimuli.\nExamples: The RRID for Psychtoolbox is 'SCR_002881',\nand that of PsychoPy is 'SCR_006571'.\n",
+            "type": "string",
+            "format": "rrid"
+          },
+          "SoftwareVersion": {
+            "name": "SoftwareVersion",
+            "display_name": "Software Version",
+            "description": "Version of the software that was used to present the stimuli.\n",
+            "type": "string"
+          },
+          "Code": {
+            "name": "Code",
+            "display_name": "Code",
+            "description": "[URI](SPEC_ROOT/02-common-principles.md#uniform-resource-indicator)\nof the code used to present the stimuli.\nPersistent identifiers such as DOIs are preferred.\nIf multiple versions of code may be hosted at the same location,\nrevision-specific URIs are recommended.\n",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      },
+      "SubjectArtefactDescription": {
+        "name": "SubjectArtefactDescription",
+        "display_name": "Subject Artefact Description",
+        "description": "Freeform description of the observed subject artefact and its possible cause\n(for example, `\"Vagus Nerve Stimulator\"`, `\"non-removable implant\"`).\nIf this field is set to `\"n/a\"`, it will be interpreted as absence of major\nsource of artifacts except cardiac and blinks.\n",
+        "type": "string"
+      },
+      "TaskDescription": {
+        "name": "TaskDescription",
+        "display_name": "Task Description",
+        "description": "Longer description of the task.\n",
+        "type": "string"
+      },
+      "TaskName": {
+        "name": "TaskName",
+        "display_name": "Task Name",
+        "description": "Name of the task.\nNo two tasks should have the same name.\nThe task label included in the file name is derived from this `\"TaskName\"` field\nby removing all non-alphanumeric characters (that is, all except those matching `[0-9a-zA-Z]`).\nFor example `\"TaskName\"` `\"faces n-back\"` will correspond to task label\n`facesnback`.\n",
+        "type": "string"
+      },
+      "TermURL": {
+        "name": "TermURL",
+        "display_name": "TermURL",
+        "description": "URL pointing to a formal definition of this type of data in an ontology\navailable on the web.\n",
+        "type": "string"
+      },
+      "TimeZero": {
+        "name": "TimeZero",
+        "display_name": "Time Zero",
+        "description": "Time zero to which all scan and/or blood measurements have been adjusted to,\nin the unit \"hh:mm:ss\".\nThis should be equal to `\"InjectionStart\"` or `\"ScanStart\"`.\n",
+        "type": "string",
+        "format": "time"
+      },
+      "TissueDeformationScaling": {
+        "name": "TissueDeformationScaling",
+        "display_name": "Tissue Deformation Scaling",
+        "description": "Estimated deformation of the tissue, given as a percentage of the original\ntissue size (for examples: for a shrinkage of 3%, the value is `97`;\nand for an expansion of 100%, the value is `200`).\n",
+        "type": "number",
+        "exclusiveMinimum": 0
+      },
+      "TissueOrigin": {
+        "name": "TissueOrigin",
+        "display_name": "Tissue Origin",
+        "description": "Describes the type of tissue analyzed for `\"SampleOrigin\"` `brain`.\n",
+        "type": "string",
+        "enum": [
+          "gray matter",
+          "white matter",
+          "csf",
+          "meninges",
+          "macrovascular",
+          "microvascular"
+        ]
+      },
+      "TotalAcquiredPairs": {
+        "name": "TotalAcquiredPairs",
+        "display_name": "Total Acquired Pairs",
+        "description": "The total number of acquired `control`-`label` pairs.\nA single pair consists of a single `control` and a single `label` image.\n",
+        "type": "number",
+        "exclusiveMinimum": 0
+      },
+      "TotalReadoutTime": {
+        "name": "TotalReadoutTime",
+        "display_name": "Total Readout Time",
+        "description": "This is actually the \"effective\" total readout time,\ndefined as the readout duration, specified in seconds,\nthat would have generated data with the given level of distortion.\nIt is NOT the actual, physical duration of the readout train.\nIf `\"EffectiveEchoSpacing\"` has been properly computed,\nit is just `EffectiveEchoSpacing * (ReconMatrixPE - 1)`.\n",
+        "type": "number",
+        "unit": "s"
+      },
+      "TracerMolecularWeight": {
+        "name": "TracerMolecularWeight",
+        "display_name": "Tracer Molecular Weight",
+        "description": "Accurate molecular weight of the tracer used.\n",
+        "type": "number"
+      },
+      "TracerMolecularWeightUnits": {
+        "name": "TracerMolecularWeightUnits",
+        "display_name": "Tracer Molecular Weight Units",
+        "description": "Unit of the molecular weights measurement (for example, `\"g/mol\"`).\n",
+        "type": "string",
+        "format": "unit"
+      },
+      "TracerName": {
+        "name": "TracerName",
+        "display_name": "Tracer Name",
+        "description": "Name of the tracer compound used (for example, `\"CIMBI-36\"`)\n",
+        "type": "string"
+      },
+      "TracerRadLex": {
+        "name": "TracerRadLex",
+        "display_name": "Tracer Rad Lex",
+        "description": "ID of the tracer compound from the RadLex Ontology.\n",
+        "type": "string"
+      },
+      "TracerRadionuclide": {
+        "name": "TracerRadionuclide",
+        "display_name": "Tracer Radionuclide",
+        "description": "Radioisotope labelling tracer (for example, `\"C11\"`).\n",
+        "type": "string"
+      },
+      "TracerSNOMED": {
+        "name": "TracerSNOMED",
+        "display_name": "TracerSNOMED",
+        "description": "ID of the tracer compound from the SNOMED Ontology\n(subclass of Radioactive isotope).\n",
+        "type": "string"
+      },
+      "TriggerChannelCount": {
+        "name": "TriggerChannelCount",
+        "display_name": "Trigger Channel Count",
+        "description": "Number of channels for digital (TTL bit level) triggers.\n",
+        "type": "integer",
+        "minimum": 0
+      },
+      "TubingLength": {
+        "name": "TubingLength",
+        "display_name": "Tubing Length",
+        "description": "The length of the blood tubing, from the subject to the detector in meters.\n",
+        "type": "number",
+        "unit": "m"
+      },
+      "TubingType": {
+        "name": "TubingType",
+        "display_name": "Tubing Type",
+        "description": "Description of the type of tubing used, ideally including the material and\n(internal) diameter.\n",
+        "type": "string"
+      },
+      "Type": {
+        "name": "Type",
+        "display_name": "Type",
+        "description": "Short identifier of the mask.\nThe value `\"Brain\"` refers to a brain mask.\nThe value `\"Lesion\"` refers to a lesion mask.\nThe value `\"Face\"` refers to a face mask.\nThe value `\"ROI\"` refers to a region of interest mask.\n",
+        "type": "string",
+        "enum": [
+          "Brain",
+          "Lesion",
+          "Face",
+          "ROI"
+        ]
+      },
+      "Units": {
+        "name": "Units",
+        "display_name": "Units",
+        "description": "Measurement units for the associated file.\nSI units in CMIXF formatting are RECOMMENDED\n(see [Units](SPEC_ROOT/02-common-principles.md#units)).\n",
+        "type": "string",
+        "format": "unit"
+      },
+      "VascularCrushing": {
+        "name": "VascularCrushing",
+        "display_name": "Vascular Crushing",
+        "description": "Boolean indicating if Vascular Crushing is used.\nCorresponds to DICOM Tag 0018, 9259 `ASL Crusher Flag`.\n",
+        "type": "boolean"
+      },
+      "VascularCrushingVENC": {
+        "name": "VascularCrushingVENC",
+        "display_name": "Vascular Crushing VENC",
+        "description": "The crusher gradient strength, in centimeters per second.\nSpecify either one number for the total time-series, or provide an array of\nnumbers, for example when using QUASAR, using the value zero to identify\nvolumes for which `VascularCrushing` was turned off.\nCorresponds to DICOM Tag 0018, 925A `ASL Crusher Flow Limit`.\n",
+        "anyOf": [
+          {
+            "type": "number",
+            "unit": "cm/s"
+          },
+          {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "unit": "cm/s"
+            }
+          }
+        ]
+      },
+      "VolumeTiming": {
+        "name": "VolumeTiming",
+        "display_name": "Volume Timing",
+        "description": "The time at which each volume was acquired during the acquisition.\nIt is described using a list of times referring to the onset of each volume\nin the BOLD series.\nThe list must have the same length as the BOLD series,\nand the values must be non-negative and monotonically increasing.\nThis field is mutually exclusive with `\"RepetitionTime\"` and `\"DelayTime\"`.\nIf defined, this requires acquisition time (TA) be defined via either\n`\"SliceTiming\"` or `\"AcquisitionDuration\"` be defined.\n",
+        "type": "array",
+        "minItems": 1,
+        "items": {
+          "type": "number",
+          "unit": "s"
+        }
+      },
+      "WholeBloodAvail": {
+        "name": "WholeBloodAvail",
+        "display_name": "Whole Blood Avail",
+        "description": "Boolean that specifies if whole blood measurements are available.\nIf `true`, the `whole_blood_radioactivity` column MUST be present in the\ncorresponding `*_blood.tsv` file.\n",
+        "type": "boolean"
+      },
+      "WithdrawalRate": {
+        "name": "WithdrawalRate",
+        "display_name": "Withdrawal Rate",
+        "description": "The rate at which the blood was withdrawn from the subject.\nThe unit of the specified withdrawal rate should be in `\"mL/s\"`.\n",
+        "type": "number",
+        "unit": "mL/s"
+      },
+      "_CoordUnits": {
+        "type": "string",
+        "enum": [
+          "m",
+          "mm",
+          "cm",
+          "n/a"
+        ]
+      },
+      "_EEGCoordSys": {
+        "type": "string",
+        "enum": [
+          "CapTrak",
+          "EEGLAB",
+          "EEGLAB-HJ",
+          "Other"
+        ]
+      },
+      "_GeneticLevelEnum": {
+        "type": "string",
+        "enum": [
+          "Genetic",
+          "Genomic",
+          "Epigenomic",
+          "Transcriptomic",
+          "Metabolomic",
+          "Proteomic"
+        ]
+      },
+      "_LandmarkCoordinates": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 3,
+          "maxItems": 3
+        }
+      },
+      "_MEGCoordSys": {
+        "type": "string",
+        "enum": [
+          "CTF",
+          "ElektaNeuromag",
+          "4DBti",
+          "KitYokogawa",
+          "ChietiItab",
+          "Other"
+        ]
+      },
+      "_StandardTemplateCoordSys": {
+        "type": "string",
+        "enum": [
+          "ICBM452AirSpace",
+          "ICBM452Warp5Space",
+          "IXI549Space",
+          "fsaverage",
+          "fsaverageSym",
+          "fsLR",
+          "MNIColin27",
+          "MNI152Lin",
+          "MNI152NLin2009aSym",
+          "MNI152NLin2009bSym",
+          "MNI152NLin2009cSym",
+          "MNI152NLin2009aAsym",
+          "MNI152NLin2009bAsym",
+          "MNI152NLin2009cAsym",
+          "MNI152NLin6Sym",
+          "MNI152NLin6ASym",
+          "MNI305",
+          "NIHPD",
+          "OASIS30AntsOASISAnts",
+          "OASIS30Atropos",
+          "Talairach",
+          "UNCInfant"
+        ]
+      },
+      "_StandardTemplateDeprecatedCoordSys": {
+        "type": "string",
+        "enum": [
+          "fsaverage3",
+          "fsaverage4",
+          "fsaverage5",
+          "fsaverage6",
+          "fsaveragesym",
+          "UNCInfant0V21",
+          "UNCInfant1V21",
+          "UNCInfant2V21",
+          "UNCInfant0V22",
+          "UNCInfant1V22",
+          "UNCInfant2V22",
+          "UNCInfant0V23",
+          "UNCInfant1V23",
+          "UNCInfant2V23"
+        ]
+      },
+      "_iEEGCoordSys": {
+        "type": "string",
+        "enum": [
+          "Pixels",
+          "ACPC",
+          "Other"
+        ]
+      },
+      "iEEGCoordinateProcessingDescription": {
+        "name": "iEEGCoordinateProcessingDescription",
+        "display_name": "iEEG Coordinate Processing Description",
+        "description": "Has any post-processing (such as projection) been done on the electrode\npositions (for example, `\"surface_projection\"`, `\"none\"`).\n",
+        "type": "string"
+      },
+      "iEEGCoordinateProcessingReference": {
+        "name": "iEEGCoordinateProcessingReference",
+        "display_name": "iEEG Coordinate Processing Reference",
+        "description": "A reference to a paper that defines in more detail the method used to\nlocalize the electrodes and to post-process the electrode positions.\n",
+        "type": "string"
+      },
+      "iEEGCoordinateSystem": {
+        "name": "iEEGCoordinateSystem",
+        "display_name": "iEEG Coordinate System",
+        "description": "Defines the coordinate system for the iEEG sensors.\nSee the\n[Coordinate Systems Appendix](SPEC_ROOT/appendices/coordinate-systems.md)\nfor a list of restricted keywords for coordinate systems.\nIf `\"Other\"`, provide definition of the coordinate system in\n`iEEGCoordinateSystemDescription`.\nIf positions correspond to pixel indices in a 2D image\n(of either a volume-rendering, surface-rendering, operative photo, or\noperative drawing), this MUST be `\"Pixels\"`.\nFor more information, see the section on\n[2D coordinate systems](SPEC_ROOT/04-modality-specific-files/04-intracranial\\\n-electroencephalography.md#allowed-2d-coordinate-systems).\n",
+        "type": "string",
+        "enum": [
+          "Pixels",
+          "ACPC",
+          "Other",
+          "ICBM452AirSpace",
+          "ICBM452Warp5Space",
+          "IXI549Space",
+          "fsaverage",
+          "fsaverageSym",
+          "fsLR",
+          "MNIColin27",
+          "MNI152Lin",
+          "MNI152NLin2009aSym",
+          "MNI152NLin2009bSym",
+          "MNI152NLin2009cSym",
+          "MNI152NLin2009aAsym",
+          "MNI152NLin2009bAsym",
+          "MNI152NLin2009cAsym",
+          "MNI152NLin6Sym",
+          "MNI152NLin6ASym",
+          "MNI305",
+          "NIHPD",
+          "OASIS30AntsOASISAnts",
+          "OASIS30Atropos",
+          "Talairach",
+          "UNCInfant",
+          "fsaverage3",
+          "fsaverage4",
+          "fsaverage5",
+          "fsaverage6",
+          "fsaveragesym",
+          "UNCInfant0V21",
+          "UNCInfant1V21",
+          "UNCInfant2V21",
+          "UNCInfant0V22",
+          "UNCInfant1V22",
+          "UNCInfant2V22",
+          "UNCInfant0V23",
+          "UNCInfant1V23",
+          "UNCInfant2V23"
+        ]
+      },
+      "iEEGCoordinateSystemDescription": {
+        "name": "iEEGCoordinateSystemDescription",
+        "display_name": "iEEG Coordinate System Description",
+        "description": "Free-form text description of the coordinate system.\nMay also include a link to a documentation page or paper describing the\nsystem in greater detail.\n",
+        "type": "string"
+      },
+      "iEEGCoordinateUnits": {
+        "name": "iEEGCoordinateUnits",
+        "display_name": "iEEG Coordinate Units",
+        "description": "Units of the `*_electrodes.tsv`.\nMUST be `\"pixels\"` if `iEEGCoordinateSystem` is `Pixels`.\n",
+        "type": "string",
+        "enum": [
+          "m",
+          "mm",
+          "cm",
+          "pixels",
+          "n/a"
+        ]
+      },
+      "iEEGElectrodeGroups": {
+        "name": "iEEGElectrodeGroups",
+        "display_name": "iEEG Electrode Groups",
+        "description": "Field to describe the way electrodes are grouped into strips, grids or depth\nprobes.\nFor example, `\"grid1: 10x8 grid on left temporal pole, strip2: 1x8 electrode\nstrip on xxx\"`.\n",
+        "type": "string"
+      },
+      "iEEGGround": {
+        "name": "iEEGGround",
+        "display_name": "iEEG Ground",
+        "description": "Description of the location of the ground electrode\n(`\"placed on right mastoid (M2)\"`).\n",
+        "type": "string"
+      },
+      "iEEGPlacementScheme": {
+        "name": "iEEGPlacementScheme",
+        "display_name": "iEEG Placement Scheme",
+        "description": "Freeform description of the placement of the iEEG electrodes.\nLeft/right/bilateral/depth/surface\n(for example, `\"left frontal grid and bilateral hippocampal depth\"` or\n`\"surface strip and STN depth\"` or\n`\"clinical indication bitemporal, bilateral temporal strips and left grid\"`).\n",
+        "type": "string"
+      },
+      "iEEGReference": {
+        "name": "iEEGReference",
+        "display_name": "iEEG Reference",
+        "description": "General description of the reference scheme used and (when applicable) of\nlocation of the reference electrode in the raw recordings\n(for example, `\"left mastoid\"`, `\"bipolar\"`,\n`\"T01\"` for electrode with name T01,\n`\"intracranial electrode on top of a grid, not included with data\"`,\n`\"upside down electrode\"`).\nIf different channels have a different reference,\nthis field should have a general description and the channel specific\nreference should be defined in the `channels.tsv` file.\n",
+        "type": "string"
+      }
+    },
+    "modalities": {
+      "mri": {
+        "display_name": "Magnetic Resonance Imaging",
+        "description": "Data acquired with an MRI scanner.\n"
+      },
+      "eeg": {
+        "display_name": "Electroencephalography",
+        "description": "Data acquired with EEG.\n"
+      },
+      "ieeg": {
+        "display_name": "Intracranial Electroencephalography",
+        "description": "Data acquired with iEEG.\n"
+      },
+      "meg": {
+        "display_name": "Magnetoencephalography",
+        "description": "Data acquired with an MEG scanner.\n"
+      },
+      "beh": {
+        "display_name": "Behavioral experiments",
+        "description": "Behavioral data acquired without accompanying neuroimaging data.\n"
+      },
+      "pet": {
+        "display_name": "Positron Emission Tomography",
+        "description": "Data acquired with PET.\n"
+      },
+      "micr": {
+        "display_name": "Microscopy",
+        "description": "Data acquired with a microscope.\n"
+      },
+      "nirs": {
+        "display_name": "Near-Infrared Spectroscopy",
+        "description": "Data acquired with NIRS."
+      }
+    },
+    "suffixes": {
+      "TwoPE": {
+        "value": "2PE",
+        "display_name": "2-photon excitation microscopy",
+        "description": "2-photon excitation microscopy imaging data\n"
+      },
+      "BF": {
+        "value": "BF",
+        "display_name": "Bright-field microscopy",
+        "description": "Bright-field microscopy imaging data\n"
+      },
+      "Chimap": {
+        "value": "Chimap",
+        "display_name": "Quantitative susceptibility map (QSM)",
+        "description": "In parts per million (ppm).\nQSM allows for determining the underlying magnetic susceptibility of tissue\n(Chi)\n([Wang & Liu, 2014](https://doi.org/10.1002/mrm.25358)).\nChi maps are REQUIRED to use this suffix regardless of the method used to\ngenerate them.\n",
+        "unit": "ppm"
+      },
+      "CARS": {
+        "value": "CARS",
+        "display_name": "Coherent anti-Stokes Raman spectroscopy",
+        "description": "Coherent anti-Stokes Raman spectroscopy imaging data\n"
+      },
+      "CONF": {
+        "value": "CONF",
+        "display_name": "Confocal microscopy",
+        "description": "Confocal microscopy imaging data\n"
+      },
+      "DIC": {
+        "value": "DIC",
+        "display_name": "Differential interference contrast microscopy",
+        "description": "Differential interference contrast microscopy imaging data\n"
+      },
+      "DF": {
+        "value": "DF",
+        "display_name": "Dark-field microscopy",
+        "description": "Dark-field microscopy imaging data\n"
+      },
+      "FLAIR": {
+        "value": "FLAIR",
+        "display_name": "Fluid attenuated inversion recovery image",
+        "description": "In arbitrary units (arbitrary).\nStructural images with predominant T2 contribution (also known as T2-FLAIR),\nin which signal from fluids (for example, CSF) is nulled out by adjusting\ninversion time, coupled with notably long repetition and echo times.\n",
+        "unit": "arbitrary"
+      },
+      "FLASH": {
+        "value": "FLASH",
+        "display_name": "Fast-Low-Angle-Shot image",
+        "description": "FLASH (Fast-Low-Angle-Shot) is a vendor-specific implementation for spoiled\ngradient echo acquisition.\nIt is commonly used for rapid anatomical imaging and also for many different\nqMRI applications.\nWhen used for a single file, it does not convey any information about the\nimage contrast.\nWhen used in a file collection, it may result in conflicts across filenames of\ndifferent applications.\n**Change:** Removed from suffixes.\n"
+      },
+      "FLUO": {
+        "value": "FLUO",
+        "display_name": "Fluorescence microscopy",
+        "description": "Fluorescence microscopy imaging data\n"
+      },
+      "IRT1": {
+        "value": "IRT1",
+        "display_name": "Inversion recovery T1 mapping",
+        "description": "The IRT1 method involves multiple inversion recovery spin-echo images\nacquired at different inversion times\n([Barral et al. 2010](https://doi.org/10.1002/mrm.22497)).\n"
+      },
+      "M0map": {
+        "value": "M0map",
+        "display_name": "Equilibrium magnetization (M0) map",
+        "description": "In arbitrary units (arbitrary).\nA common quantitative MRI (qMRI) fitting variable that represents the amount\nof magnetization at thermal equilibrium.\nM0 maps are RECOMMENDED to use this suffix if generated by qMRI applications\n(for example, variable flip angle T1 mapping).\n",
+        "unit": "arbitrary"
+      },
+      "MEGRE": {
+        "value": "MEGRE",
+        "display_name": "Multi-echo Gradient Recalled Echo",
+        "description": "Anatomical gradient echo images acquired at different echo times.\nPlease note that this suffix is not intended for the logical grouping of\nimages acquired using an Echo Planar Imaging (EPI) readout.\n"
+      },
+      "MESE": {
+        "value": "MESE",
+        "display_name": "Multi-echo Spin Echo",
+        "description": "The MESE method involves multiple spin echo images acquired at different echo\ntimes and is primarily used for T2 mapping.\nPlease note that this suffix is not intended for the logical grouping of\nimages acquired using an Echo Planar Imaging (EPI) readout.\n"
+      },
+      "MP2RAGE": {
+        "value": "MP2RAGE",
+        "display_name": "Magnetization Prepared Two Gradient Echoes",
+        "description": "The MP2RAGE method is a special protocol that collects several images at\ndifferent flip angles and inversion times to create a parametric T1map by\ncombining the magnitude and phase images\n([Marques et al. 2010](https://doi.org/10.1016/j.neuroimage.2009.10.002)).\n"
+      },
+      "MPE": {
+        "value": "MPE",
+        "display_name": "Multi-photon excitation microscopy",
+        "description": "Multi-photon excitation microscopy imaging data\n"
+      },
+      "MPM": {
+        "value": "MPM",
+        "display_name": "Multi-parametric Mapping",
+        "description": "The MPM approaches (a.k.a hMRI) involves the acquisition of highly-similar\nanatomical images that differ in terms of application of a magnetization\ntransfer RF pulse (MTon or MToff), flip angle and (optionally) echo time and\nmagnitue/phase parts\n([Weiskopf et al. 2013](https://doi.org/10.3389/fnins.2013.00095)).\nSee [here](https://owncloud.gwdg.de/index.php/s/iv2TOQwGy4FGDDZ) for\nsuggested MPM acquisition protocols.\n"
+      },
+      "MTR": {
+        "value": "MTR",
+        "display_name": "Magnetization Transfer Ratio",
+        "description": "This method is to calculate a semi-quantitative magnetization transfer ratio\nmap.\n"
+      },
+      "MTRmap": {
+        "value": "MTRmap",
+        "display_name": "Magnetization transfer ratio image",
+        "description": "In arbitrary units (arbitrary).\nMTR maps are REQUIRED to use this suffix regardless of the method used to\ngenerate them.\nMTRmap intensity values are RECOMMENDED to be represented in percentage in\nthe range of 0-100%.\n",
+        "unit": "arbitrary",
+        "minValue": 0,
+        "maxValue": 100
+      },
+      "MTS": {
+        "value": "MTS",
+        "display_name": "Magnetization transfer saturation",
+        "description": "This method is to calculate a semi-quantitative magnetization transfer\nsaturation index map.\nThe MTS method involves three sets of anatomical images that differ in terms\nof application of a magnetization transfer RF pulse (MTon or MToff) and flip\nangle ([Helms et al. 2008](https://doi.org/10.1002/mrm.21732)).\n"
+      },
+      "MTVmap": {
+        "value": "MTVmap",
+        "display_name": "Macromolecular tissue volume (MTV) image",
+        "description": "In arbitrary units (arbitrary).\nMTV maps are REQUIRED to use this suffix regardless of the method used to\ngenerate them.\n",
+        "unit": "arbitrary"
+      },
+      "MTsat": {
+        "value": "MTsat",
+        "display_name": "Magnetization transfer saturation image",
+        "description": "In arbitrary units (arbitrary).\nMTsat maps are REQUIRED to use this suffix regardless of the method used to\ngenerate them.\n",
+        "unit": "arbitrary"
+      },
+      "MWFmap": {
+        "value": "MWFmap",
+        "display_name": "Myelin water fraction image",
+        "description": "In arbitrary units (arbitrary).\nMWF maps are REQUIRED to use this suffix regardless of the method used to\ngenerate them.\nMWF intensity values are RECOMMENDED to be represented in percentage in the\nrange of 0-100%.\n",
+        "unit": "arbitrary",
+        "minValue": 0,
+        "maxValue": 100
+      },
+      "NLO": {
+        "value": "NLO",
+        "display_name": "Nonlinear optical microscopy",
+        "description": "Nonlinear optical microscopy imaging data\n"
+      },
+      "OCT": {
+        "value": "OCT",
+        "display_name": "Optical coherence tomography",
+        "description": "Optical coherence tomography imaging data\n"
+      },
+      "PC": {
+        "value": "PC",
+        "display_name": "Phase-contrast microscopy",
+        "description": "Phase-contrast microscopy imaging data\n"
+      },
+      "PD": {
+        "value": "PD",
+        "display_name": "Proton density image",
+        "description": "Ambiguous, may refer to a parametric image or to a conventional image.\n**Change:** Replaced by `PDw` or `PDmap`.\n",
+        "unit": "arbitrary"
+      },
+      "PDT2": {
+        "value": "PDT2",
+        "display_name": "PD and T2 weighted image",
+        "description": "In arbitrary units (arbitrary).\nPDw and T2w images acquired using a dual echo FSE sequence through view\nsharing process\n([Johnson et al. 1994](https://pubmed.ncbi.nlm.nih.gov/8010268/)).\n",
+        "unit": "arbitrary"
+      },
+      "PDT2map": {
+        "value": "PDT2map",
+        "display_name": "Combined PD/T2 image",
+        "description": "In arbitrary units (arbitrary).\nCombined PD/T2 maps are REQUIRED to use this suffix regardless of the method\nused to generate them.\n",
+        "unit": "arbitrary"
+      },
+      "PDmap": {
+        "value": "PDmap",
+        "display_name": "Proton density image",
+        "description": "In arbitrary units (arbitrary).\nPD maps are REQUIRED to use this suffix regardless of the method used to\ngenerate them.\n",
+        "unit": "arbitrary"
+      },
+      "PDw": {
+        "value": "PDw",
+        "display_name": "Proton density (PD) weighted image",
+        "description": "In arbitrary units (arbitrary).\nThe contrast of these images is mainly determined by spatial variations in\nthe spin density (1H) of the imaged specimen.\nIn spin-echo sequences this contrast is achieved at short repetition and long\necho times.\nIn a gradient-echo acquisition, PD weighting dominates the contrast at long\nrepetition and short echo times, and at small flip angles.\n",
+        "unit": "arbitrary"
+      },
+      "PLI": {
+        "value": "PLI",
+        "display_name": "Polarized-light microscopy",
+        "description": "Polarized-light microscopy imaging data\n"
+      },
+      "R1map": {
+        "value": "R1map",
+        "display_name": "Longitudinal relaxation rate image",
+        "description": "In seconds<sup>-1</sup> (1/s).\nR1 maps (R1 = 1/T1) are REQUIRED to use this suffix regardless of the method\nused to generate them.\n",
+        "unit": "1/s"
+      },
+      "R2map": {
+        "value": "R2map",
+        "display_name": "True transverse relaxation rate image",
+        "description": "In seconds<sup>-1</sup> (1/s).\nR2 maps (R2 = 1/T2) are REQUIRED to use this suffix regardless of the method\nused to generate them.\n",
+        "unit": "1/s"
+      },
+      "R2starmap": {
+        "value": "R2starmap",
+        "display_name": "Observed transverse relaxation rate image",
+        "description": "In seconds<sup>-1</sup> (1/s).\nR2-star maps (R2star = 1/T2star) are REQUIRED to use this suffix regardless\nof the method used to generate them.\n",
+        "unit": "1/s"
+      },
+      "RB1COR": {
+        "value": "RB1COR",
+        "display_name": "RB1COR",
+        "description": "Low resolution images acquired by the body coil\n(in the gantry of the scanner) and the head coil using identical acquisition\nparameters to generate a combined sensitivity map as described in\n[Papp et al. (2016)](https://doi.org/10.1002/mrm.26058).\n"
+      },
+      "RB1map": {
+        "value": "RB1map",
+        "display_name": "RF receive sensitivity map",
+        "description": "In arbitrary units (arbitrary).\nRadio frequency (RF) receive (B1-) sensitivity maps are REQUIRED to use this\nsuffix regardless of the method used to generate them.\nRB1map intensity values are RECOMMENDED to be represented as percent\nmultiplicative factors such that Amplitude<sub>effective</sub> =\nB1-<sub>intensity</sub>\\*Amplitude<sub>ideal</sub>.\n",
+        "unit": "arbitrary"
+      },
+      "S0map": {
+        "value": "S0map",
+        "display_name": "Observed signal amplitude (S0) image",
+        "description": "In arbitrary units (arbitrary).\nFor a multi-echo (typically fMRI) sequence, S0 maps index the baseline signal\nbefore exponential (T2-star) signal decay.\nIn other words: the exponential of the intercept for a linear decay model\nacross log-transformed echos. For more information, please see, for example,\n[the tedana documentation](https://tedana.readthedocs.io/en/latest/\\\napproach.html#monoexponential-decay-model-fit).\nS0 maps are RECOMMENDED to use this suffix if derived from an ME-FMRI dataset.\n"
+      },
+      "SEM": {
+        "value": "SEM",
+        "display_name": "Scanning electron microscopy",
+        "description": "Scanning electron microscopy imaging data\n"
+      },
+      "SPIM": {
+        "value": "SPIM",
+        "display_name": "Selective plane illumination microscopy",
+        "description": "Selective plane illumination microscopy imaging data\n"
+      },
+      "SR": {
+        "value": "SR",
+        "display_name": "Super-resolution microscopy",
+        "description": "Super-resolution microscopy imaging data\n"
+      },
+      "T1map": {
+        "value": "T1map",
+        "display_name": "Longitudinal relaxation time image",
+        "description": "In seconds (s).\nT1 maps are REQUIRED to use this suffix regardless of the method used to\ngenerate them.\nSee [this interactive book on T1 mapping](https://qmrlab.org/t1_book/intro)\nfor further reading on T1-mapping.\n",
+        "unit": "s"
+      },
+      "T1rho": {
+        "value": "T1rho",
+        "display_name": "T1 in rotating frame (T1 rho) image",
+        "description": "In seconds (s).\nT1-rho maps are REQUIRED to use this suffix regardless of the method used to\ngenerate them.\n",
+        "unit": "s"
+      },
+      "T1w": {
+        "value": "T1w",
+        "display_name": "T1-weighted image",
+        "description": "In arbitrary units (arbitrary).\nThe contrast of these images is mainly determined by spatial variations in\nthe longitudinal relaxation time of the imaged specimen.\nIn spin-echo sequences this contrast is achieved at relatively short\nrepetition and echo times.\nTo achieve this weighting in gradient-echo images, again, short repetition\nand echo times are selected; however, at relatively large flip angles.\nAnother common approach to increase T1 weighting in gradient-echo images is\nto add an inversion preparation block to the beginning of the imaging\nsequence (for example, `TurboFLASH` or `MP-RAGE`).\n",
+        "unit": "arbitrary"
+      },
+      "T2map": {
+        "value": "T2map",
+        "display_name": "True transverse relaxation time image",
+        "description": "In seconds (s).\nT2 maps are REQUIRED to use this suffix regardless of the method used to\ngenerate them.\n",
+        "unit": "s"
+      },
+      "T2star": {
+        "value": "T2star",
+        "display_name": "T2\\* image",
+        "description": "Ambiguous, may refer to a parametric image or to a conventional image.\n**Change:** Replaced by `T2starw` or `T2starmap`.\n",
+        "anyOf": [
+          {
+            "unit": "arbitrary"
+          },
+          {
+            "unit": "s"
+          }
+        ]
+      },
+      "T2starmap": {
+        "value": "T2starmap",
+        "display_name": "Observed transverse relaxation time image",
+        "description": "In seconds (s).\nT2-star maps are REQUIRED to use this suffix regardless of the method used to\ngenerate them.\n",
+        "unit": "s"
+      },
+      "T2starw": {
+        "value": "T2starw",
+        "display_name": "T2star weighted image",
+        "description": "In arbitrary units (arbitrary).\nThe contrast of these images is mainly determined by spatial variations in\nthe (observed) transverse relaxation time of the imaged specimen.\nIn spin-echo sequences, this effect is negated as the excitation is followed\nby an inversion pulse.\nThe contrast of gradient-echo images natively depends on T2-star effects.\nHowever, for T2-star variation to dominate the image contrast,\ngradient-echo acquisitions are carried out at long repetition and echo times,\nand at small flip angles.\n",
+        "unit": "arbitrary"
+      },
+      "T2w": {
+        "value": "T2w",
+        "display_name": "T2-weighted image",
+        "description": "In arbitrary units (arbitrary).\nThe contrast of these images is mainly determined by spatial variations in\nthe (true) transverse relaxation time of the imaged specimen.\nIn spin-echo sequences this contrast is achieved at relatively long\nrepetition and echo times.\nGenerally, gradient echo sequences are not the most suitable option for\nachieving T2 weighting, as their contrast natively depends on T2-star rather\nthan on T2.\n",
+        "unit": "arbitrary"
+      },
+      "TB1AFI": {
+        "value": "TB1AFI",
+        "display_name": "TB1AFI",
+        "description": "This method ([Yarnykh 2007](https://doi.org/10.1002/mrm.21120))\ncalculates a B1<sup>+</sup> map from two images acquired at interleaved (two)\nTRs with identical RF pulses using a steady-state sequence.\n"
+      },
+      "TB1DAM": {
+        "value": "TB1DAM",
+        "display_name": "TB1DAM",
+        "description": "The double-angle B1<sup>+</sup> method\n([Insko and Bolinger 1993](https://doi.org/10.1006/jmra.1993.1133)) is based\non the calculation of the actual angles from signal ratios,\ncollected by two acquisitions at different nominal excitation flip angles.\nCommon sequence types for this application include spin echo and echo planar\nimaging.\n"
+      },
+      "TB1EPI": {
+        "value": "TB1EPI",
+        "display_name": "TB1EPI",
+        "description": "This B1<sup>+</sup> mapping method\n([Jiru and Klose 2006](https://doi.org/10.1002/mrm.21083)) is based on two\nEPI readouts to acquire spin echo (SE) and stimulated echo (STE) images at\nmultiple flip angles in one sequence, used in the calculation of deviations\nfrom the nominal flip angle.\n"
+      },
+      "TB1RFM": {
+        "value": "TB1RFM",
+        "display_name": "TB1RFM",
+        "description": "The result of a Siemens `rf_map` product sequence.\nThis sequence produces two images.\nThe first image appears like an anatomical image and the second output is a\nscaled flip angle map.\n"
+      },
+      "TB1SRGE": {
+        "value": "TB1SRGE",
+        "display_name": "TB1SRGE",
+        "description": "Saturation-prepared with 2 rapid gradient echoes (SA2RAGE) uses a ratio of\ntwo saturation recovery images with different time delays,\nand a simulated look-up table to estimate B1+\n([Eggenschwiler et al. 2011](https://doi.org/10.1002/mrm.23145)).\nThis sequence can also be used in conjunction with MP2RAGE T1 mapping to\niteratively improve B1+ and T1 map estimation\n([Marques & Gruetter 2013](https://doi.org/10.1371/journal.pone.0069294)).\n"
+      },
+      "TB1TFL": {
+        "value": "TB1TFL",
+        "display_name": "TB1TFL",
+        "description": "The result of a Siemens `tfl_b1_map` product sequence.\nThis sequence produces two images.\nThe first image appears like an anatomical image and the second output is a\nscaled flip angle map.\n"
+      },
+      "TB1map": {
+        "value": "TB1map",
+        "display_name": "RF transmit field image",
+        "description": "In arbitrary units (arbitrary).\nRadio frequency (RF) transmit (B1+) field maps are REQUIRED to use this\nsuffix regardless of the method used to generate them.\nTB1map intensity values are RECOMMENDED to be represented as percent\nmultiplicative factors such that FlipAngle<sub>effective</sub> =\nB1+<sub>intensity</sub>\\*FlipAngle<sub>nominal</sub> .\n",
+        "unit": "arbitrary"
+      },
+      "TEM": {
+        "value": "TEM",
+        "display_name": "Transmission electron microscopy",
+        "description": "Transmission electron microscopy imaging data\n"
+      },
+      "UNIT1": {
+        "value": "UNIT1",
+        "display_name": "Homogeneous (flat) T1-weighted MP2RAGE image",
+        "description": "In arbitrary units (arbitrary).\nUNIT1 images are REQUIRED to use this suffix regardless of the method used to\ngenerate them.\nNote that although this image is T1-weighted, regions without MR signal will\ncontain white salt-and-pepper noise that most segmentation algorithms will\nfail on.\nTherefore, it is important to dissociate it from `T1w`.\nPlease see [`MP2RAGE` specific notes](SPEC_ROOT/appendices/qmri.md#unit1-images)\nin the qMRI appendix for further information.\n"
+      },
+      "VFA": {
+        "value": "VFA",
+        "display_name": "Variable flip angle",
+        "description": "The VFA method involves at least two spoiled gradient echo (SPGR) of\nsteady-state free precession (SSFP) images acquired at different flip angles.\nDepending on the provided metadata fields and the sequence type,\ndata may be eligible for DESPOT1, DESPOT2 and their variants\n([Deoni et al. 2005](https://doi.org/10.1002/mrm.20314)).\n"
+      },
+      "angio": {
+        "value": "angio",
+        "display_name": "Angiogram",
+        "description": "Magnetic resonance angiography sequences focus on enhancing the contrast of\nblood vessels (generally arteries, but sometimes veins) against other tissue\ntypes.\n"
+      },
+      "asl": {
+        "value": "asl",
+        "display_name": "Arterial Spin Labeling",
+        "description": "The complete ASL time series stored as a 4D NIfTI file in the original\nacquisition order, with possible volume types including: control, label,\nm0scan, deltam, cbf.\n"
+      },
+      "aslcontext": {
+        "value": "aslcontext",
+        "display_name": "Arterial Spin Labeling Context",
+        "description": "A TSV file defining the image types for volumes in an associated ASL file.\n"
+      },
+      "asllabeling": {
+        "value": "asllabeling",
+        "display_name": "ASL Labeling Screenshot",
+        "description": "An anonymized screenshot of the planning of the labeling slab/plane with\nrespect to the imaging slab or slices `*_asllabeling.jpg`.\nBased on DICOM macro C.8.13.5.14.\n"
+      },
+      "beh": {
+        "value": "beh",
+        "display_name": "Behavioral recording",
+        "description": "Behavioral recordings from tasks.\nThese files are similar to events files, but do not include the `\"onset\"` and\n`\"duration\"` columns that are mandatory for events files.\n"
+      },
+      "blood": {
+        "value": "blood",
+        "display_name": "Blood recording data",
+        "description": "Blood measurements of radioactivity stored in\n[tabular files](SPEC_ROOT/02-common-principles.md#tabular-files)\nand located in the `pet/` directory along with the corresponding PET data.\n"
+      },
+      "bold": {
+        "value": "bold",
+        "display_name": "Blood-Oxygen-Level Dependent image",
+        "description": "Blood-Oxygen-Level Dependent contrast (specialized T2\\* weighting)\n"
+      },
+      "cbv": {
+        "value": "cbv",
+        "display_name": "Cerebral blood volume image",
+        "description": "Cerebral Blood Volume contrast (specialized T2\\* weighting or difference between T1 weighted images)\n"
+      },
+      "channels": {
+        "value": "channels",
+        "display_name": "Channels File",
+        "description": "Channel information.\n"
+      },
+      "coordsystem": {
+        "value": "coordsystem",
+        "display_name": "Coordinate System File",
+        "description": "A JSON document specifying the coordinate system(s) used for the MEG, EEG,\nhead localization coils, and anatomical landmarks.\n"
+      },
+      "defacemask": {
+        "value": "defacemask",
+        "display_name": "Defacing Mask",
+        "description": "A binary mask that was used to remove facial features from an anatomical MRI\nimage.\n"
+      },
+      "dseg": {
+        "value": "dseg",
+        "display_name": "Discrete Segmentation",
+        "description": "A discrete segmentation.\n\nThis suffix may only be used in derivative datasets.\n"
+      },
+      "dwi": {
+        "value": "dwi",
+        "display_name": "Diffusion-weighted image",
+        "description": "Diffusion-weighted imaging contrast (specialized T2 weighting).\n"
+      },
+      "eeg": {
+        "value": "eeg",
+        "display_name": "Electroencephalography",
+        "description": "Electroencephalography recording data.\n"
+      },
+      "electrodes": {
+        "value": "electrodes",
+        "display_name": "Electrodes",
+        "description": "File that gives the location of (i)EEG electrodes.\n"
+      },
+      "epi": {
+        "value": "epi",
+        "display_name": "EPI",
+        "description": "The phase-encoding polarity (PEpolar) technique combines two or more Spin Echo\nEPI scans with different phase encoding directions to estimate the underlying\ninhomogeneity/deformation map.\n"
+      },
+      "events": {
+        "value": "events",
+        "display_name": "Events",
+        "description": "Event timing information from a behavioral task.\n"
+      },
+      "fieldmap": {
+        "value": "fieldmap",
+        "display_name": "Fieldmap",
+        "description": "Some MR schemes such as spiral-echo imaging (SEI) sequences are able to\ndirectly provide maps of the *B<sub>0</sub>* field inhomogeneity.\n"
+      },
+      "headshape": {
+        "value": "headshape",
+        "display_name": "Headshape File",
+        "description": "The 3-D locations of points that describe the head shape and/or electrode\nlocations can be digitized and stored in separate files.\n"
+      },
+      "ieeg": {
+        "value": "ieeg",
+        "display_name": "Intracranial Electroencephalography",
+        "description": "Intracranial electroencephalography recording data.\n"
+      },
+      "inplaneT1": {
+        "value": "inplaneT1",
+        "display_name": "Inplane T1",
+        "description": "In arbitrary units (arbitrary).\nT1 weighted structural image matched to a functional (task) image.\n",
+        "unit": "arbitrary"
+      },
+      "inplaneT2": {
+        "value": "inplaneT2",
+        "display_name": "Inplane T2",
+        "description": "In arbitrary units (arbitrary).\nT2 weighted structural image matched to a functional (task) image.\n",
+        "unit": "arbitrary"
+      },
+      "m0scan": {
+        "value": "m0scan",
+        "display_name": "M0 image",
+        "description": "The M0 image is a calibration image, used to estimate the equilibrium\nmagnetization of blood.\n"
+      },
+      "magnitude": {
+        "value": "magnitude",
+        "display_name": "Magnitude",
+        "description": "Field-mapping MR schemes such as gradient-recalled echo (GRE) generate a\nMagnitude image to be used for anatomical reference.\nRequires the existence of Phase, Phase-difference or Fieldmap maps.\n"
+      },
+      "magnitude1": {
+        "value": "magnitude1",
+        "display_name": "Magnitude",
+        "description": "Magnitude map generated by GRE or similar schemes, associated with the first\necho in the sequence.\n"
+      },
+      "magnitude2": {
+        "value": "magnitude2",
+        "display_name": "Magnitude",
+        "description": "Magnitude map generated by GRE or similar schemes, associated with the second\necho in the sequence.\n"
+      },
+      "markers": {
+        "value": "markers",
+        "display_name": "MEG Sensor Coil Positions",
+        "description": "Another manufacturer-specific detail pertains to the KIT/Yokogawa/Ricoh\nsystem, which saves the MEG sensor coil positions in a separate file with two\npossible filename extensions  (`.sqd`, `.mrk`).\nFor these files, the `markers` suffix MUST be used.\nFor example: `sub-01_task-nback_markers.sqd`\n"
+      },
+      "mask": {
+        "value": "mask",
+        "display_name": "Binary Mask",
+        "description": "A binary mask that functions as a discrete \"label\" for a single structure.\n\nThis suffix may only be used in derivative datasets.\n"
+      },
+      "meg": {
+        "value": "meg",
+        "display_name": "Magnetoencephalography",
+        "description": "Unprocessed MEG data stored in the native file format of the MEG instrument\nwith which the data was collected.\n"
+      },
+      "nirs": {
+        "value": "nirs",
+        "display_name": "Near Infrared Spectroscopy",
+        "description": "Data associated with a Shared Near Infrared Spectroscopy Format file."
+      },
+      "optodes": {
+        "value": "optodes",
+        "display_name": "Optodes",
+        "description": "Either a light emitting device, sometimes called a transmitter, or a photoelectric transducer, sometimes called a\nreceiver.\n"
+      },
+      "pet": {
+        "value": "pet",
+        "display_name": "Positron Emission Tomography",
+        "description": "PET imaging data SHOULD be stored in 4D\n(or 3D, if only one volume was acquired) NIfTI files with the `_pet` suffix.\nVolumes MUST be stored in chronological order\n(the order they were acquired in).\n"
+      },
+      "phase": {
+        "value": "phase",
+        "display_name": "Phase image",
+        "description": "[DEPRECATED](SPEC_ROOT/02-common-principles.md#definitions).\nPhase information associated with magnitude information stored in BOLD\ncontrast.\nThis suffix should be replaced by the\n[`part-phase`](SPEC_ROOT/appendices/entities.md#part)\nin conjunction with the `bold` suffix.\n",
+        "anyOf": [
+          {
+            "unit": "arbitrary"
+          },
+          {
+            "unit": "rad"
+          }
+        ]
+      },
+      "phase1": {
+        "value": "phase1",
+        "display_name": "Phase",
+        "description": "Phase map generated by GRE or similar schemes, associated with the first\necho in the sequence.\n"
+      },
+      "phase2": {
+        "value": "phase2",
+        "display_name": "Phase",
+        "description": "Phase map generated by GRE or similar schemes, associated with the second\necho in the sequence.\n"
+      },
+      "phasediff": {
+        "value": "phasediff",
+        "display_name": "Phase-difference",
+        "description": "Some scanners subtract the `phase1` from the `phase2` map and generate a\nunique `phasediff` file.\nFor instance, this is a common output for the built-in fieldmap sequence of\nSiemens scanners.\n"
+      },
+      "photo": {
+        "value": "photo",
+        "display_name": "Photo File",
+        "description": "Photos of the anatomical landmarks, head localization coils or tissue sample.\n"
+      },
+      "physio": {
+        "value": "physio",
+        "display_name": "Physiological recording",
+        "description": "Physiological recordings such as cardiac and respiratory signals.\n"
+      },
+      "probseg": {
+        "value": "probseg",
+        "display_name": "Probabilistic Segmentation",
+        "description": "A probabilistic segmentation.\n\nThis suffix may only be used in derivative datasets.\n"
+      },
+      "sbref": {
+        "value": "sbref",
+        "display_name": "Single-band reference image",
+        "description": "Single-band reference for one or more multi-band `dwi` images.\n"
+      },
+      "scans": {
+        "value": "scans",
+        "display_name": "Scans file",
+        "description": "The purpose of this file is to describe timing and other properties of each imaging acquisition\nsequence (each run file) within one session.\nEach neural recording file SHOULD be described by exactly one row. Some recordings consist of\nmultiple parts, that span several files, for example through echo-, part-, or split- entities.\nSuch recordings MUST be documented with one row per file.\nRelative paths to files should be used under a compulsory filename header.\nIf acquisition time is included it should be listed under the acq_time header.\nAcquisition time refers to when the first data point in each run was acquired.\nFurthermore, if this header is provided, the acquisition times of all files that belong to a\nrecording MUST be identical.\nDatetime should be expressed as described in Units.\nAdditional fields can include external behavioral measures relevant to the scan.\nFor example vigilance questionnaire score administered after a resting state scan.\nAll such included additional fields SHOULD be documented in an accompanying _scans.json file\nthat describes these fields in detail (see Tabular files).\n"
+      },
+      "sessions": {
+        "value": "sessions",
+        "display_name": "Sessions file",
+        "description": "In case of multiple sessions there is an option of adding additional sessions.tsv files\ndescribing variables changing between sessions.\nIn such case one file per participant SHOULD be added.\nThese files MUST include a session_id column and describe each session by one and only one row.\nColumn names in sessions.tsv files MUST be different from group level participant key column\nnames in the participants.tsv file.\n"
+      },
+      "stim": {
+        "value": "stim",
+        "display_name": "Continuous recording",
+        "description": "Continuous measures, such as parameters of a film or audio stimulus.\n"
+      },
+      "uCT": {
+        "value": "uCT",
+        "display_name": "Micro-CT",
+        "description": "Micro-CT imaging data\n"
+      }
+    }
+  },
+  "rules": {
+    "checks": {
+      "asl": {
+        "ASLLabelingDurationNiftiLength": {
+          "issue": {
+            "code": "LABELING_DURATION_LENGTH_NOT_MATCHING_NIFTI",
+            "message": "The number of values for 'LabelingDuration' for this file does not match the 4th dimension\nof the NIfTI header.\n'LabelingDuration' is the total duration of the labeling pulse train, in seconds,\ncorresponding to the temporal width of the labeling bolus for `(P)CASL`.\nIn case all control-label volumes (or deltam or CBF) have the same `LabelingDuration`, a scalar must be\nspecified.\nIn case the control-label volumes (or deltam or cbf) have a different `LabelingDuration`,\nan array of numbers must be specified, for which any `m0scan` in the timeseries has a `LabelingDuration` of\nzero.\nIn case an array of numbers is provided, its length should be equal to the number of volumes specified in\n`*_aslcontext.tsv`. Corresponds to DICOM Tag 0018,9258 `ASL Pulse Train Duration`.\n",
+            "level": "error"
+          },
+          "selectors": [
+            "suffix == \"asl\"",
+            "\"LabelingDuration\" in sidecar",
+            "type(sidecar.LabelingDuration) == 'array'"
+          ],
+          "checks": [
+            "length(sidecar.LabelingDuration) == nifti_header.dim[4]"
+          ]
+        },
+        "ASLContextConsistent": {
+          "issue": {
+            "code": "ASLCONTEXT_TSV_NOT_CONSISTENT",
+            "message": "The number of volumes in the '*_aslcontext.tsv' for this file does not match the number of\nvalues in the NIfTI header.\n",
+            "level": "error"
+          },
+          "selectors": [
+            "suffix == \"asl\"",
+            "\"aslcontext\" in associations"
+          ],
+          "checks": [
+            "nifti_header.dim[4] == associations.aslcontext.n_rows"
+          ]
+        },
+        "ASLFlipAngleNiftiLength": {
+          "issue": {
+            "code": "FLIP_ANGLE_NOT_MATCHING_NIFTI",
+            "message": "The number of values for 'FlipAngle' for this file does not match the 4th dimension of the NIfTI header.\n'FlipAngle' is the flip angle (FA) for the acquisition, specified in degrees.\nCorresponds to: DICOM Tag 0018, 1314 `Flip Angle`.\nThe data type number may apply to files from any MRI modality concerned with a single value for this field,\nor to the files in a file collection where the value of this field is iterated using the flip entity.\nThe data type array provides a value for each volume in a 4D dataset and should only be used when the\nvolume timing is critical for interpretation of the data, such as in ASL or variable flip\nangle fMRI sequences.\n",
+            "level": "error"
+          },
+          "selectors": [
+            "suffix == \"asl\"",
+            "\"FlipAngle\" in sidecar",
+            "type(sidecar.FlipAngle) == 'array'"
+          ],
+          "checks": [
+            "length(sidecar.FlipAngle) == nifti_header.dim[4]"
+          ]
+        },
+        "ASLFlipAngleASLContextLength": {
+          "issue": {
+            "code": "FLIP_ANGLE_NOT_MATCHING_ASLCONTEXT_TSV",
+            "message": "The number of values for 'FlipAngle' for this file does not match the number of volumes in the\n'sub-<label>[_ses-<label>][_acq-<label>][_rec-<label>][_run-<index>]_aslcontext.tsv'.\n'FlipAngle' is the flip angle (FA) for the acquisition, specified in degrees.\nCorresponds to: DICOM Tag 0018, 1314 `Flip Angle`.\nThe data type number may apply to files from any MRI modality concerned with a single value for this field,\nor to the files in a file collection where the value of this field is iterated using the flip entity.\nThe data type array provides a value for each volume in a 4D dataset and should only be used when the volume\ntiming is critical for interpretation of the data, such as in ASL or variable flip angle fMRI sequences.\n",
+            "level": "error"
+          },
+          "selectors": [
+            "suffix == \"asl\"",
+            "\"aslcontext\" in associations",
+            "\"FlipAngle\" in sidecar",
+            "type(sidecar.FlipAngle) == 'array'"
+          ],
+          "checks": [
+            "length(sidecar.FlipAngle) == aslcontext.n_rows"
+          ]
+        },
+        "ASLPostLabelingDelayNiftiLength": {
+          "issue": {
+            "code": "POST_LABELING_DELAY_NOT_MATCHING_NIFTI",
+            "message": "The number of values for 'PostLabelingDelay' for this file does not match the 4th dimension of the NIfTI\nheader.\n'PostLabelingDelay' is the time, in seconds, after the end of the labeling (for (P)CASL) or middle of the\nlabeling pulse (for PASL) until the middle of the excitation pulse applied to the imaging slab\n(for 3D acquisition) or first slice (for 2D acquisition).\nCan be a number (for a single-PLD time series) or an array of numbers (for multi-PLD and Look-Locker).\nIn the latter case, the array of numbers contains the PLD of each volume\n(that is, each 'control' and 'label')\nin the acquisition order. Any image within the time-series without a PLD (for example, an 'm0scan') is\nindicated by a zero.\nBased on DICOM Tags 0018,9079 Inversion Times and 0018,0082 InversionTime.\n",
+            "level": "error"
+          },
+          "selectors": [
+            "suffix == \"asl\"",
+            "\"aslcontext\" in associations",
+            "type(sidecar.PostLabelingDelay) == 'array'"
+          ],
+          "checks": [
+            "length(sidecar.PostLabelingDelay) == nifti_header.dim[4]"
+          ]
+        },
+        "ASLPostLabelingDelayASLContextLength": {
+          "issue": {
+            "code": "POST_LABELING_DELAY_NOT_MATCHING_ASLCONTEXT_TSV",
+            "message": "The number of values for 'PostLabelingDelay' for this file does not match the number of volumes\nin the 'sub-<label>[_ses-<label>][_acq-<label>][_rec-<label>][_run-<index>]_aslcontext.tsv'.\n'PostLabelingDelay' is the time, in seconds, after the end of the labeling (for (P)CASL) or\nmiddle of the labeling pulse (for PASL) until the middle of the excitation pulse applied to\nthe imaging slab (for 3D acquisition) or first slice (for 2D acquisition).\nCan be a number (for a single-PLD time series) or an array of numbers (for multi-PLD and Look-Locker).\nIn the latter case, the array of numbers contains the PLD of each volume\n(that is, each 'control' and 'label')\nin the acquisition order.\nAny image within the time-series without a PLD (for example, an 'm0scan') is indicated by a zero.\nBased on DICOM Tags 0018,9079 Inversion Times and 0018,0082 InversionTime.\n",
+            "level": "error"
+          },
+          "selectors": [
+            "suffix == \"asl\"",
+            "\"aslcontext\" in associations",
+            "type(sidecar.PostLabelingDelay) == 'array'"
+          ],
+          "checks": [
+            "length(sidecar.PostLabelingDelay) == aslcontext.n_rows"
+          ]
+        },
+        "ASLLabelingDurationASLContextLength": {
+          "issue": {
+            "code": "LABELLING_DURATION_NOT_MATCHING_ASLCONTEXT_TSV",
+            "message": "The number of values for 'LabelingDuration' for this file does not match the number of volumes\nin the 'sub-<label>[_ses-<label>][_acq-<label>][_rec-<label>][_run-<index>]_aslcontext.tsv'.\n'LabelingDuration' is the total duration of the labeling pulse train, in seconds,\ncorresponding to the temporal width of the labeling bolus for `(P)CASL`.\nIn case all control-label volumes (or deltam or CBF) have the same `LabelingDuration`,\na scalar must be specified.\nIn case the control-label volumes (or deltam or cbf) have a different `LabelingDuration`,\nan array of numbers must be specified, for which any `m0scan` in the timeseries has a\n`LabelingDuration` of zero.\nIn case an array of numbers is provided, its length should be equal to the number of volumes\nspecified in `*_aslcontext.tsv`.\nCorresponds to DICOM Tag 0018,9258 `ASL Pulse Train Duration`.\n",
+            "level": "error"
+          },
+          "selectors": [
+            "suffix == \"asl\"",
+            "\"aslcontext\" in associations",
+            "\"LabelingDuration\" in sidecar",
+            "type(sidecar.LabelingDuration) == 'array'"
+          ],
+          "checks": [
+            "length(sidecar.LabelingDuration) == aslcontext.n_rows"
+          ]
+        },
+        "ASLRepetitionTimePreparationASLContextLength": {
+          "issue": {
+            "code": "REPETITIONTIMEPREPARATION_NOT_MATCHING_ASLCONTEXT_TSV",
+            "message": "The number of values of 'RepetitionTimePreparation' for this file does not match the number of\nvolumes in the 'sub-<label>[_ses-<label>][_acq-<label>][_rec-<label>][_run-<index>]_aslcontext.tsv'.\n'RepetitionTimePreparation' is the interval, in seconds, that it takes a preparation pulse block to\nre-appear at the beginning of the succeeding (essentially identical) pulse sequence block.\nThe data type number may apply to files from any MRI modality concerned with a single value for this field.\nThe data type array provides a value for each volume in a 4D dataset and should only be used when the\nvolume timing is critical for interpretation of the data, such as in ASL.\n",
+            "level": "error"
+          },
+          "selectors": [
+            "suffix == \"asl\"",
+            "\"aslcontext\" in associations",
+            "\"RepetitionTimePreparation\" in sidecar",
+            "type(sidecar.RepetitionTimePreparation) == 'array'"
+          ],
+          "checks": [
+            "length(sidecar.RepetitionTimePreparation) == aslcontext.n_rows"
+          ]
+        },
+        "ASLBackgroundSuppressionNumberPulses": {
+          "issue": {
+            "code": "BACKGROUND_SUPPRESSION_PULSE_NUMBER_NOT_CONSISTENT",
+            "message": "The 'BackgroundSuppressionNumberPulses' field is not consistent with the length of\n'BackgroundSuppressionPulseTime'.\n'BackgroundSuppressionNumberPulses' is the number of background suppression pulses used.\nNote that this excludes any effect of background suppression pulses applied before the labeling.\n",
+            "level": "warning"
+          },
+          "selectors": [
+            "suffix == \"asl\"",
+            "\"BackgroundSuppressionNumberPulses\" in sidecar",
+            "\"BackgroundSuppressionPulseTime\" in sidecar",
+            "type(sidecar.BackgroundSuppressionPulseTime) == 'array'"
+          ],
+          "checks": [
+            "length(sidecar.BackgroundSuppressionPulseTime) == sidecar.BackgroundSuppressionNumberPulses"
+          ]
+        },
+        "ASLTotalAcquiredVolumesASLContextLength": {
+          "issue": {
+            "code": "TOTAL_ACQUIRED_VOLUMES_NOT_CONSISTENT",
+            "message": "The number of values for 'TotalAcquiredVolumes' for this file does not match number of\nvolumes in the 'sub-<label>[_ses-<label>][_acq-<label>][_rec-<label>][_run-<index>]_aslcontext.tsv'.\n'TotalAcquiredVolumes' is the original number of 3D volumes acquired for each volume defined in the\n'sub-<label>[_ses-<label>][_acq-<label>][_rec-<label>][_run-<index>]_aslcontext.tsv'.\n",
+            "level": "warning"
+          },
+          "selectors": [
+            "suffix == \"asl\"",
+            "\"aslcontext\" in associations",
+            "\"TotalAcquiredVolumes\" in sidecar"
+          ],
+          "checks": [
+            "aslcontext.n_rows == sidecar.TotalAcquiredVolumes"
+          ]
+        },
+        "ASLEchoTimeASLContextLength": {
+          "issue": {
+            "code": "ECHO_TIME_NOT_CONSISTENT",
+            "message": "The number of values for 'EchoTime' for this file does not match number of volumes in the\n'sub-<label>[_ses-<label>][_acq-<label>][_rec-<label>][_run-<index>]_aslcontext.tsv'.\n'EchoTime' is the echo time (TE) for the acquisition, specified in seconds.\n",
+            "level": "warning"
+          },
+          "selectors": [
+            "suffix == \"asl\"",
+            "\"aslcontext\" in associations",
+            "\"EchoTime\" in sidecar",
+            "type(sidecar.EchoTime) == 'array'"
+          ],
+          "checks": [
+            "length(sidecar.EchoTime) == aslcontext.n_rows"
+          ]
+        },
+        "ASLM0TypeAbsentScan": {
+          "issue": {
+            "code": "M0Type_SET_INCORRECTLY_TO_ABSENT",
+            "message": "You defined M0Type as 'absent' while including a separate '*_m0scan.nii[.gz]' and\n'*_m0scan.json', or defining the 'M0Estimate' field.\nThis is not allowed, please check that this field are filled correctly.\n",
+            "level": "error"
+          },
+          "selectors": [
+            "suffix == \"asl\"",
+            "\"aslcontext\" in associations",
+            "\"m0scan\" in associations",
+            "\"M0Type\" in sidecar"
+          ],
+          "checks": [
+            "sidecar.M0Type != \"absent\""
+          ]
+        },
+        "ASLM0TypeAbsentASLContext": {
+          "issue": {
+            "code": "M0Type_SET_INCORRECTLY_TO_ABSENT_IN_ASLCONTEXT",
+            "message": "You defined M0Type as 'absent' while including an m0scan volume within the '*_aslcontext.tsv'.\nThis is not allowed, please check that this field are filled correctly.\n",
+            "level": "error"
+          },
+          "selectors": [
+            "suffix == \"asl\"",
+            "\"aslcontext\" in associations",
+            "intersects(aslcontext.volume_type, [\"m0scan\"])",
+            "\"M0Type\" in sidecar"
+          ],
+          "checks": [
+            "sidecar.M0Type != \"absent\""
+          ]
+        },
+        "ASLM0TypeIncorrect": {
+          "issue": {
+            "code": "M0Type_SET_INCORRECTLY",
+            "message": "M0Type was not defined correctly.\nIf 'M0Type' is equal to 'separate', the dataset should include a *_m0scan.nii[.gz] and *_m0scan.json file.\n",
+            "level": "error"
+          },
+          "selectors": [
+            "suffix == \"asl\"",
+            "\"aslcontext\" in associations",
+            "\"M0Type\" in sidecar",
+            "sidecar.M0Type == \"separate\""
+          ],
+          "checks": [
+            "\"m0scan\" in associations"
+          ]
+        }
+      },
+      "common_derivatives": {
+        "ResInSidecar": {
+          "selectors": [
+            "dataset.dataset_description.DatasetType == \"derivative\"",
+            "intersects([modality], [\"mri\", \"pet\"])",
+            "match(extension, '^\\.nii(\\.gz)?$')",
+            "type(sidecar.Resolution) == \"object\""
+          ],
+          "checks": [
+            "entities.resolution in sidecar.Resolution"
+          ]
+        },
+        "DenInSidecar": {
+          "selectors": [
+            "dataset.dataset_description.DatasetType == \"derivative\"",
+            "intersects([modality], [\"mri\", \"pet\"])",
+            "match(extension, '^\\.nii(\\.gz)?$')",
+            "type(sidecar.Density) == \"object\""
+          ],
+          "checks": [
+            "entities.density in sidecar.Density"
+          ]
+        }
+      },
+      "dwi": {
+        "DWIVolumeCount": {
+          "issue": {
+            "code": "VOLUME_COUNT_MISMATCH",
+            "message": "The number of volumes in this scan does not match the number of volumes in the\ncorresponding .bvec and .bval files.\n",
+            "level": "error"
+          },
+          "selectors": [
+            "suffix == \"dwi\"",
+            "\"bval\" in associations",
+            "\"bvec\" in associations"
+          ],
+          "checks": [
+            "associations.bval.n_cols == nifti_header.dim[4]",
+            "associations.bvec.n_cols == nifti_header.dim[4]"
+          ]
+        },
+        "DWIBvalRows": {
+          "issue": {
+            "code": "BVAL_MULTIPLE_ROWS",
+            "message": "'.bval' files should contain exactly one row of volumes.\n",
+            "level": "error"
+          },
+          "selectors": [
+            "extension == \"bval\""
+          ],
+          "checks": [
+            "data.n_rows == 1"
+          ]
+        },
+        "DWIBvecRows": {
+          "issue": {
+            "code": "BVEC_NUMBER_ROWS",
+            "message": "'.bvec' files should contain exactly three rows of volumes.\n",
+            "level": "error"
+          },
+          "selectors": [
+            "extension == \"bvec\""
+          ],
+          "checks": [
+            "data.n_rows == 3"
+          ]
+        },
+        "DWIMissingBvec": {
+          "issue": {
+            "code": "DWI_MISSING_BVEC",
+            "message": "DWI scans must have a corresponding .bvec file.\n",
+            "level": "error"
+          },
+          "selectors": [
+            "suffix == \"dwi\""
+          ],
+          "checks": [
+            "\"bvec\" in associations"
+          ]
+        },
+        "DWIMissingBval": {
+          "issue": {
+            "code": "DWI_MISSING_BVAL",
+            "message": "DWI scans must have a corresponding .bval file.\n",
+            "level": "error"
+          },
+          "selectors": [
+            "suffix == \"dwi\""
+          ],
+          "checks": [
+            "\"bval\" in associations"
+          ]
+        }
+      },
+      "events": {
+        "EventsMissing": {
+          "issue": {
+            "code": "EVENTS_TSV_MISSING",
+            "message": "Task scans should have a corresponding events.tsv file.\nIf this is a resting state scan you can ignore this warning or rename the task to include the word \"rest\".\n",
+            "level": "warning"
+          },
+          "selectors": [
+            "dataset.dataset_description.DatasetType == \"raw\"",
+            "\"task\" in entities",
+            "!match(entities.task, \"rest\")",
+            "suffix != \"events\""
+          ],
+          "checks": [
+            "\"events\" in associations"
+          ]
+        }
+      },
+      "fmap": {
+        "FmapFieldmapWithoutMagnitude": {
+          "issue": {
+            "code": "_FIELDMAP_WITHOUT_MAGNITUDE_FILE",
+            "message": "'_fieldmap.nii[.gz]' file does not have accompanying '_magnitude.nii[.gz]' file.\n",
+            "level": "error"
+          },
+          "selectors": [
+            "suffix == \"fieldmap\""
+          ],
+          "checks": [
+            "\"magnitude\" in associations"
+          ]
+        },
+        "FmapPhasediffWithoutMagnitude": {
+          "issue": {
+            "code": "MISSING_MAGNITUDE1_FILE",
+            "message": "Each '_phasediff.nii[.gz]' file should be associations with a '_magnitude1.nii[.gz]' file.\n",
+            "level": "warning"
+          },
+          "selectors": [
+            "suffix == \"phasediff\""
+          ],
+          "checks": [
+            "\"magnitude1\" in associations"
+          ]
+        }
+      },
+      "func": {
+        "PhaseSuffixDeprecated": {
+          "issue": {
+            "code": "PHASE_SUFFIX_DEPRECATED",
+            "message": "DEPRECATED. Phase information associated with magnitude information stored in BOLD contrast.\nThis suffix should be replaced by the part-phase in conjunction with the bold suffix.\nFor backwards compatibility, _phase is considered equivalent to _part-phase_bold.\nWhen the _phase suffix is not used, each file shares the same name with the exception of the\npart-<mag|phase> or part-<real|imag> key/value.\n",
+            "level": "warning"
+          },
+          "selectors": [
+            "datatype == \"func\""
+          ],
+          "checks": [
+            "suffix != \"phase\""
+          ]
+        }
+      },
+      "hints": {
+        "SuspiciouslyLongBOLDDesign": {
+          "issue": {
+            "code": "SUSPICIOUSLY_LONG_EVENT_DESIGN",
+            "message": "The onset of the last event is after the total duration of the corresponding scan.\nThis design is suspiciously long.\n",
+            "level": "warning"
+          },
+          "selectors": [
+            "suffix == \"bold\"",
+            "associations.events != null"
+          ],
+          "checks": [
+            "max(associations.events.onset) < nifti_header.pixdim[4] * nifti_header.dim[4]"
+          ]
+        },
+        "SuspiciouslyShortBOLDDesign": {
+          "issue": {
+            "code": "SUSPICIOUSLY_SHORT_EVENT_DESIGN",
+            "message": "The onset of the last event is less than half the total duration of the corresponding scan.\nThis design is suspiciously short.\n",
+            "level": "warning"
+          },
+          "selectors": [
+            "suffix == \"bold\"",
+            "associations.events != null"
+          ],
+          "checks": [
+            "max(associations.events.onset) > nifti_header.pixdim[4] * nifti_header.dim[4] / 2"
+          ]
+        }
+      },
+      "mri": {
+        "PhasePartUnits": {
+          "issue": {
+            "code": "PHASE_UNITS",
+            "message": "Phase images (with the `part-phase` entity) must have units\n\"rad\" or \"arbitrary\".\n",
+            "level": "error"
+          },
+          "selectors": [
+            "modality == \"mri\"",
+            "entities.part == \"phase\"",
+            "\"Units\" in sidecar"
+          ],
+          "checks": [
+            "intersects([sidecar.Units], [\"rad\", \"arbitrary\"])"
+          ]
+        }
+      },
+      "nirs": {
+        "NASamplingFreq": {
+          "selectors": [
+            "suffix == \"nirs\"",
+            "samplingFrequency == \"n/a\""
+          ],
+          "checks": [
+            "associations.channels.sampling_frequency != null"
+          ]
+        },
+        "NIRSChannelCount": {
+          "selectors": [
+            "datatype == \"nirs\"",
+            "suffix == \"nirs\""
+          ],
+          "checks": [
+            "sidecar.NIRSChannelCount\n== count(associations.channels.type, \"NIRSCWAMPLITUDE\")\n+  count(associations.channels.type, \"NIRSCWFLUORESCENSEAMPLITUDE\")\n+  count(associations.channels.type, \"NIRSCWOPTICALDENSITY\")\n+  count(associations.channels.type, \"NIRSCWHBO\")\n+  count(associations.channels.type, \"NIRSCWHBR\")\n+  count(associations.channels.type, \"NIRSCWMUA\")\n"
+          ]
+        },
+        "ACCELChannelCountReq": {
+          "selectors": [
+            "suffix == \"nirs\""
+          ],
+          "checks": [
+            "sidecar.ACCELChannelCount == count(associations.channels.type, \"ACCEL\")"
+          ]
+        },
+        "GYROChannelCountReq": {
+          "selectors": [
+            "suffix == \"nirs\""
+          ],
+          "checks": [
+            "sidecar.GYROChannelCount == count(associations.channels.type, \"GYRO\")"
+          ]
+        },
+        "MAGNChannelCountReq": {
+          "selectors": [
+            "suffix == \"nirs\""
+          ],
+          "checks": [
+            "sidecar.MAGNChannelCount == count(associations.channels.type, \"MAGN\")"
+          ]
+        },
+        "ShortChannelCountReq": {
+          "selectors": [
+            "suffix == \"nirs\""
+          ],
+          "checks": [
+            "sidecar.ShortChannelCount == count(associations.channels.short_channel, true)"
+          ]
+        },
+        "OrientationComponent": {
+          "selectors": [
+            "datatype == \"nirs\"",
+            "suffix == \"channels\"",
+            "extension == \".tsv\"",
+            "intersect(columns.type, [\"ACCEL\", \"GYRO\", \"MAGN\"])"
+          ],
+          "checks": [
+            "columns.orientation_component != null"
+          ]
+        },
+        "RequiredChannels": {
+          "selectors": [
+            "datatype == \"nirs\"",
+            "suffix == \"optodes\"",
+            "extension == \".tsv\""
+          ],
+          "checks": [
+            "associations.channels != null"
+          ]
+        },
+        "RequiredTemplateX": {
+          "selectors": [
+            "datatype == \"nirs\"",
+            "suffix == \"optodes\"",
+            "extension == \".tsv\"",
+            "intersect(columns.x, [\"n/a\"])"
+          ],
+          "checks": [
+            "columns.template_x != null"
+          ]
+        },
+        "RequiredTemplateY": {
+          "selectors": [
+            "datatype == \"nirs\"",
+            "suffix == \"optodes\"",
+            "extension == \".tsv\"",
+            "intersect(columns.y, [\"n/a\"])"
+          ],
+          "checks": [
+            "columns.template_y != null"
+          ]
+        },
+        "RequiredTemplateZ": {
+          "selectors": [
+            "datatype == \"nirs\"",
+            "suffix == \"optodes\"",
+            "extension == \".tsv\"",
+            "intersect(columns.z, [\"n/a\"])"
+          ],
+          "checks": [
+            "columns.template_z != null"
+          ]
+        },
+        "RequiredCoordsystem": {
+          "selectors": [
+            "datatype == \"nirs\"",
+            "suffix == \"optodes\"",
+            "extension == \".tsv\""
+          ],
+          "checks": [
+            "associations.coordsystem != null"
+          ]
+        }
+      }
+    },
+    "common_principles": [
+      "dataset",
+      "modality",
+      "data_type",
+      "subject",
+      "session",
+      "sample",
+      "data_acquisition",
+      "task",
+      "event",
+      "run",
+      "index",
+      "label",
+      "suffix",
+      "extension",
+      "deprecated"
+    ],
+    "dataset_metadata": {
+      "dataset_description": {
+        "selectors": [
+          "path == \"/dataset_description.json\""
+        ],
+        "fields": {
+          "Name": "required",
+          "BIDSVersion": "required",
+          "DatasetType": "recommended",
+          "License": "recommended",
+          "Authors": {
+            "level": "recommended",
+            "issue": {
+              "code": "NO_AUTHORS",
+              "message": "The Authors field of dataset_description.json should contain an array of fields -\nwith one author per field. This was triggered because there are no authors, which\nwill make DOI registration from dataset metadata impossible.\n"
+            }
+          },
+          "Acknowledgements": "optional",
+          "HowToAcknowledge": "optional",
+          "Funding": "optional",
+          "EthicsApprovals": "optional",
+          "ReferencesAndLinks": "optional",
+          "DatasetDOI": "optional",
+          "GeneratedBy": "recommended",
+          "GeneratedBy[]": {
+            "Container{}": {
+              "URI": "recommended"
+            }
+          },
+          "SourceDatasets": "recommended"
+        }
+      },
+      "derivative_description": {
+        "selectors": [
+          "path == \"/dataset_description.json\"",
+          "json.DatasetType == \"derivative\""
+        ],
+        "fields": {
+          "GeneratedBy": "required"
+        }
+      },
+      "dataset_description_with_genetics": {
+        "selectors": [
+          "path == \"/dataset_description.json\"",
+          "intersects(dataset.files, [\"/genetic_info.json\"])"
+        ],
+        "fields": {
+          "Genetics": "required",
+          "Genetics{}": {
+            "Descriptors": "optional"
+          }
+        }
+      },
+      "genetic_info": {
+        "selectors": [
+          "path == \"/genetic_info.json\""
+        ],
+        "fields": {
+          "GeneticLevel": "required",
+          "SampleOrigin": "required",
+          "AnalyticalApproach": "optional",
+          "TissueOrigin": "optional",
+          "BrainLocation": "optional",
+          "CellType": "optional"
+        }
+      }
+    },
+    "entities": [
+      "subject",
+      "session",
+      "sample",
+      "task",
+      "acquisition",
+      "ceagent",
+      "tracer",
+      "stain",
+      "reconstruction",
+      "direction",
+      "run",
+      "modality",
+      "echo",
+      "flip",
+      "inversion",
+      "mtransfer",
+      "part",
+      "processing",
+      "hemisphere",
+      "space",
+      "split",
+      "recording",
+      "chunk",
+      "atlas",
+      "resolution",
+      "density",
+      "label",
+      "description"
+    ],
+    "errors": {
+      "NiftiHeaderUnreadable": {
+        "code": "NIFTI_HEADER_UNREADABLE",
+        "message": "We were unable to parse header data from this NIfTI file.\nPlease ensure it is not corrupted or mislabeled.\n",
+        "level": "error",
+        "selectors": [
+          "match(extension, '^\\.nii(\\.gz)?$')"
+        ]
+      },
+      "JsonInvalid": {
+        "code": "JSON_INVALID",
+        "message": "Not a valid JSON file.\n",
+        "level": "error",
+        "selectors": [
+          "extension == \".json\""
+        ]
+      },
+      "GzNotGzipped": {
+        "code": "GZ_NOT_GZIPPED",
+        "message": "This file ends in the .gz extension but is not actually gzipped.\n",
+        "level": "error",
+        "selectors": [
+          "match(extension, '\\.gz$')"
+        ]
+      },
+      "BvalMultipleRows": {
+        "code": "BVAL_MULTIPLE_ROWS",
+        "message": ".bval files should contain exactly one row of volumes.\n",
+        "level": "error",
+        "selectors": [
+          "extension == \".bval\""
+        ]
+      },
+      "BvecNumberRows": {
+        "code": "BVEC_NUMBER_ROWS",
+        "message": ".bvec files should contain exactly three rows of volumes.\n",
+        "level": "error",
+        "selectors": [
+          "extension == \".bvec\""
+        ]
+      },
+      "NiftiTooSmall": {
+        "code": "NIFTI_TOO_SMALL",
+        "message": "This file is too small to contain the minimal NIfTI header.\n",
+        "level": "error",
+        "selectors": [
+          "match(extension, '^\\.nii(\\.gz)?$')"
+        ]
+      },
+      "OrphanedSymlink": {
+        "code": "ORPHANED_SYMLINK",
+        "message": "This file appears to be an orphaned symlink.\nMake sure it correctly points to its referent.\n",
+        "level": "error"
+      },
+      "FileRead": {
+        "code": "FILE_READ",
+        "message": "We were unable to read this file.\nMake sure it contains data (file size > 0 kB) and is not corrupted,\nincorrectly named, or incorrectly symlinked.\n",
+        "level": "error"
+      },
+      "BvecRowLength": {
+        "code": "BVEC_ROW_LENGTH",
+        "message": "Each row in a .bvec file should contain the same number of values.\n",
+        "level": "error",
+        "selectors": [
+          "extension == \".bvec\""
+        ]
+      },
+      "BFile": {
+        "code": "B_FILE",
+        "message": ".bval and .bvec files must be single space delimited\nand contain only numerical values.\n",
+        "level": "error",
+        "selectors": [
+          "intersects([extension], [\".bval\", \".bvec\"])"
+        ]
+      },
+      "JsonSchemaValidationError": {
+        "code": "JSON_SCHEMA_VALIDATION_ERROR",
+        "message": "Invalid JSON file. The file is not formatted according the schema.\n",
+        "level": "error",
+        "selectors": [
+          "extension == \".json\""
+        ]
+      },
+      "NoValidDataFoundForSubject": {
+        "code": "NO_VALID_DATA_FOUND_FOR_SUBJECT",
+        "message": "No BIDS compatible data found for at least one subject.\n",
+        "level": "error"
+      },
+      "WrongNewLine": {
+        "code": "WRONG_NEW_LINE",
+        "message": "All TSV files must use Line Feed '\\n' characters to denote new lines.\nThis files uses Carriage Return '\\r'.\n",
+        "level": "error",
+        "selectors": [
+          "extension == \".tsv\""
+        ]
+      },
+      "MalformedBvec": {
+        "code": "MALFORMED_BVEC",
+        "message": "The contents of this .bvec file are undefined or severely malformed.\n",
+        "level": "error",
+        "selectors": [
+          "extension == \".bvec\""
+        ]
+      },
+      "MalformedBval": {
+        "code": "MALFORMED_BVAL",
+        "message": "The contents of this .bval file are undefined or severely malformed.\n",
+        "level": "error",
+        "selectors": [
+          "extension == \".bval\""
+        ]
+      },
+      "SidecarWithoutDatafile": {
+        "code": "SIDECAR_WITHOUT_DATAFILE",
+        "message": "A json sidecar file was found without a corresponding data file.\n",
+        "level": "error",
+        "selectors": [
+          "extension == \".json\""
+        ]
+      },
+      "MissingSession": {
+        "code": "MISSING_SESSION",
+        "message": "Not all subjects contain the same sessions.\n",
+        "level": "warning"
+      },
+      "InaccessibleRemoteFile": {
+        "code": "INACCESSIBLE_REMOTE_FILE",
+        "message": "This file appears to be a symlink to a remote annexed file,\nbut could not be accessed from any of the configured remotes.\n",
+        "level": "error"
+      },
+      "EmptyFile": {
+        "code": "EMPTY_FILE",
+        "message": "Empty files not allowed.\n",
+        "level": "error"
+      },
+      "BrainvisionLinksBroken": {
+        "code": "BRAINVISION_LINKS_BROKEN",
+        "message": "Internal file pointers in BrainVision file triplet (*.eeg, *.vhdr,\nand *.vmrk) are broken or some files do not exist.\n",
+        "level": "error",
+        "selectors": [
+          "intersects([extension], [\".eeg\", \".vhdr\", \".vmrk\"])"
+        ]
+      },
+      "HedError": {
+        "code": "HED_ERROR",
+        "message": "The validation on this HED string returned an error.\n",
+        "level": "error",
+        "selectors": [
+          "suffix == \"events\"",
+          "extension == \".tsv\""
+        ]
+      },
+      "HedWarning": {
+        "code": "HED_WARNING",
+        "message": "The validation on this HED string returned a warning.\n",
+        "level": "warning",
+        "selectors": [
+          "suffix == \"events\"",
+          "extension == \".tsv\""
+        ]
+      },
+      "HedInternalError": {
+        "code": "HED_INTERNAL_ERROR",
+        "message": "An internal error occurred during HED validation.\n",
+        "level": "error",
+        "selectors": [
+          "suffix == \"events\"",
+          "extension == \".tsv\""
+        ]
+      },
+      "HedInternalWarning": {
+        "code": "HED_INTERNAL_WARNING",
+        "message": "An internal warning occurred during HED validation.\n",
+        "level": "warning",
+        "selectors": [
+          "suffix == \"events\"",
+          "extension == \".tsv\""
+        ]
+      },
+      "HedMissingValueInSidecar": {
+        "code": "HED_MISSING_VALUE_IN_SIDECAR",
+        "message": "The json sidecar does not contain this column value as\na possible key to a HED string.\n",
+        "level": "warning",
+        "selectors": [
+          "suffix == \"events\"",
+          "extension == \".tsv\""
+        ]
+      },
+      "HedVersionNotDefined": {
+        "code": "HED_VERSION_NOT_DEFINED",
+        "message": "You should define 'HEDVersion' for this file.\nIf you don't provide this information, the HED validation will use\nthe latest version available.\n",
+        "level": "warning",
+        "selectors": [
+          "suffix == \"events\"",
+          "extension == \".tsv\""
+        ]
+      },
+      "InvalidJsonEncoding": {
+        "code": "INVALID_JSON_ENCODING",
+        "message": "JSON files must be valid utf-8.\n",
+        "level": "error",
+        "selectors": [
+          "extension == \".json\""
+        ]
+      }
+    },
+    "files": {
+      "common": {
+        "core": {
+          "dataset_description": {
+            "level": "required",
+            "path": "dataset_description.json"
+          },
+          "README": {
+            "level": "required",
+            "stem": "README",
+            "extensions": [
+              "",
+              ".md",
+              ".rst",
+              ".txt"
+            ]
+          },
+          "CHANGES": {
+            "level": "optional",
+            "path": "CHANGES"
+          },
+          "LICENSE": {
+            "level": "optional",
+            "path": "LICENSE"
+          },
+          "genetic_info": {
+            "level": "optional",
+            "path": "genetic_info.json"
+          },
+          "code": {
+            "level": "optional",
+            "path": "code"
+          },
+          "derivatives": {
+            "level": "optional",
+            "path": "derivatives"
+          },
+          "sourcedata": {
+            "level": "optional",
+            "path": "sourcedata"
+          },
+          "stimuli": {
+            "level": "optional",
+            "path": "stimuli"
+          }
+        },
+        "tables": {
+          "participants": {
+            "level": "optional",
+            "stem": "participants",
+            "extensions": [
+              ".tsv",
+              ".json"
+            ]
+          },
+          "samples": {
+            "level": "optional",
+            "stem": "samples",
+            "extensions": [
+              ".tsv",
+              ".json"
+            ]
+          },
+          "scans": {
+            "level": "optional",
+            "suffixes": [
+              "scans"
+            ],
+            "extensions": [
+              ".tsv",
+              ".json"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional"
+            }
+          },
+          "sessions": {
+            "level": "optional",
+            "suffixes": [
+              "sessions"
+            ],
+            "extensions": [
+              ".tsv",
+              ".json"
+            ],
+            "entities": {
+              "subject": "required"
+            }
+          }
+        }
+      },
+      "deriv": {
+        "imaging": {
+          "anat_parametric_volumetric": {
+            "entities": {
+              "space": "optional",
+              "resolution": "optional",
+              "density": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "run": "optional"
+            },
+            "suffixes": [
+              "T1map",
+              "T2map",
+              "T2starmap",
+              "R1map",
+              "R2map",
+              "R2starmap",
+              "PDmap",
+              "MTRmap",
+              "MTsat",
+              "UNIT1",
+              "T1rho",
+              "MWFmap",
+              "MTVmap",
+              "PDT2map",
+              "Chimap",
+              "S0map",
+              "M0map"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "anat"
+            ]
+          },
+          "anat_nonparametric_volumetric": {
+            "entities": {
+              "space": "optional",
+              "resolution": "optional",
+              "density": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "run": "optional",
+              "part": "optional"
+            },
+            "suffixes": [
+              "T1w",
+              "T2w",
+              "PDw",
+              "T2starw",
+              "FLAIR",
+              "inplaneT1",
+              "inplaneT2",
+              "PDT2",
+              "angio",
+              "T2star",
+              "FLASH",
+              "PD"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "anat"
+            ]
+          },
+          "dwi_volumetric": {
+            "entities": {
+              "space": "optional",
+              "resolution": "optional",
+              "density": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "reconstruction": "optional",
+              "direction": "optional",
+              "run": "optional",
+              "part": "optional"
+            },
+            "suffixes": [
+              "dwi"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json",
+              ".bvec",
+              ".bval"
+            ],
+            "datatypes": [
+              "dwi"
+            ]
+          },
+          "func_volumetric": {
+            "entities": {
+              "space": "optional",
+              "resolution": "optional",
+              "density": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "task": "required",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "direction": "optional",
+              "run": "optional",
+              "echo": "optional",
+              "part": "optional"
+            },
+            "suffixes": [
+              "bold",
+              "cbv",
+              "sbref"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "func"
+            ]
+          },
+          "anat_parametric_mask": {
+            "suffixes": [
+              "mask"
+            ],
+            "entities": {
+              "space": "optional",
+              "resolution": "optional",
+              "density": "optional",
+              "label": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "run": "optional"
+            },
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "anat"
+            ]
+          },
+          "anat_nonparametric_mask": {
+            "suffixes": [
+              "mask"
+            ],
+            "entities": {
+              "space": "optional",
+              "resolution": "optional",
+              "density": "optional",
+              "label": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "run": "optional",
+              "part": "optional"
+            },
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "anat"
+            ]
+          },
+          "dwi_mask": {
+            "suffixes": [
+              "mask"
+            ],
+            "entities": {
+              "space": "optional",
+              "resolution": "optional",
+              "density": "optional",
+              "label": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "reconstruction": "optional",
+              "direction": "optional",
+              "run": "optional",
+              "part": "optional"
+            },
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json",
+              ".bvec",
+              ".bval"
+            ],
+            "datatypes": [
+              "dwi"
+            ]
+          },
+          "func_mask": {
+            "suffixes": [
+              "mask"
+            ],
+            "entities": {
+              "space": "optional",
+              "resolution": "optional",
+              "density": "optional",
+              "label": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "task": "required",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "direction": "optional",
+              "run": "optional",
+              "echo": "optional",
+              "part": "optional"
+            },
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "func"
+            ]
+          },
+          "anat_parametric_discrete_segmentation": {
+            "suffixes": [
+              "dseg"
+            ],
+            "entities": {
+              "space": "optional",
+              "resolution": "optional",
+              "density": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "run": "optional"
+            },
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "anat"
+            ]
+          },
+          "anat_nonparametric_discrete_segmentation": {
+            "suffixes": [
+              "dseg"
+            ],
+            "entities": {
+              "space": "optional",
+              "resolution": "optional",
+              "density": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "run": "optional",
+              "part": "optional"
+            },
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "anat"
+            ]
+          },
+          "func_discrete_segmentation": {
+            "suffixes": [
+              "dseg"
+            ],
+            "entities": {
+              "space": "optional",
+              "resolution": "optional",
+              "density": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "task": "required",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "direction": "optional",
+              "run": "optional",
+              "echo": "optional",
+              "part": "optional"
+            },
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "func"
+            ]
+          },
+          "dwi_discrete_segmentation": {
+            "suffixes": [
+              "dseg"
+            ],
+            "entities": {
+              "space": "optional",
+              "resolution": "optional",
+              "density": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "reconstruction": "optional",
+              "direction": "optional",
+              "run": "optional",
+              "part": "optional"
+            },
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json",
+              ".bvec",
+              ".bval"
+            ],
+            "datatypes": [
+              "dwi"
+            ]
+          },
+          "anat_parametric_probabilistic_segmentation": {
+            "suffixes": [
+              "probseg"
+            ],
+            "entities": {
+              "space": "optional",
+              "resolution": "optional",
+              "density": "optional",
+              "label": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "run": "optional"
+            },
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "anat"
+            ]
+          },
+          "anat_nonparametric_probabilistic_segmentation": {
+            "suffixes": [
+              "probseg"
+            ],
+            "entities": {
+              "space": "optional",
+              "resolution": "optional",
+              "density": "optional",
+              "label": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "run": "optional",
+              "part": "optional"
+            },
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "anat"
+            ]
+          },
+          "func_probabilistic_segmentation": {
+            "suffixes": [
+              "probseg"
+            ],
+            "entities": {
+              "space": "optional",
+              "resolution": "optional",
+              "density": "optional",
+              "label": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "task": "required",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "direction": "optional",
+              "run": "optional",
+              "echo": "optional",
+              "part": "optional"
+            },
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "func"
+            ]
+          },
+          "dwi_probabilistic_segmentation": {
+            "suffixes": [
+              "probseg"
+            ],
+            "entities": {
+              "space": "optional",
+              "resolution": "optional",
+              "density": "optional",
+              "label": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "reconstruction": "optional",
+              "direction": "optional",
+              "run": "optional",
+              "part": "optional"
+            },
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json",
+              ".bvec",
+              ".bval"
+            ],
+            "datatypes": [
+              "dwi"
+            ]
+          },
+          "anat_parametic_discrete_surface": {
+            "suffixes": [
+              "dseg"
+            ],
+            "extensions": [
+              ".label.gii",
+              ".dlabel.nii",
+              ".json"
+            ],
+            "entities": {
+              "hemisphere": "optional",
+              "space": "optional",
+              "resolution": "optional",
+              "density": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "run": "optional"
+            },
+            "datatypes": [
+              "anat"
+            ]
+          },
+          "anat_nonparametic_discrete_surface": {
+            "suffixes": [
+              "dseg"
+            ],
+            "extensions": [
+              ".label.gii",
+              ".dlabel.nii",
+              ".json"
+            ],
+            "entities": {
+              "hemisphere": "optional",
+              "space": "optional",
+              "resolution": "optional",
+              "density": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "run": "optional",
+              "part": "optional"
+            },
+            "datatypes": [
+              "anat"
+            ]
+          }
+        },
+        "preprocessed_data": {
+          "anat_nonparametric_common": {
+            "entities": {
+              "space": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "run": "optional",
+              "part": "optional"
+            },
+            "suffixes": [
+              "T1w",
+              "T2w",
+              "PDw",
+              "T2starw",
+              "FLAIR",
+              "inplaneT1",
+              "inplaneT2",
+              "PDT2",
+              "angio",
+              "T2star",
+              "FLASH",
+              "PD"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "anat"
+            ]
+          },
+          "anat_parametric_common": {
+            "entities": {
+              "space": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "run": "optional"
+            },
+            "suffixes": [
+              "T1map",
+              "T2map",
+              "T2starmap",
+              "R1map",
+              "R2map",
+              "R2starmap",
+              "PDmap",
+              "MTRmap",
+              "MTsat",
+              "UNIT1",
+              "T1rho",
+              "MWFmap",
+              "MTVmap",
+              "PDT2map",
+              "Chimap",
+              "S0map",
+              "M0map"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "anat"
+            ]
+          },
+          "anat_defacemask_common": {
+            "entities": {
+              "space": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "run": "optional",
+              "modality": "optional"
+            },
+            "suffixes": [
+              "defacemask"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "anat"
+            ]
+          },
+          "anat_multiecho_common": {
+            "entities": {
+              "space": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "run": "optional",
+              "echo": "required",
+              "part": "optional"
+            },
+            "suffixes": [
+              "MESE",
+              "MEGRE"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "anat"
+            ]
+          },
+          "anat_multiflip_common": {
+            "entities": {
+              "space": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "run": "optional",
+              "echo": "optional",
+              "flip": "required",
+              "part": "optional"
+            },
+            "suffixes": [
+              "VFA"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "anat"
+            ]
+          },
+          "anat_multiinversion_common": {
+            "entities": {
+              "space": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "run": "optional",
+              "inversion": "required",
+              "part": "optional"
+            },
+            "suffixes": [
+              "IRT1"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "anat"
+            ]
+          },
+          "anat_mp2rage_common": {
+            "entities": {
+              "space": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "run": "optional",
+              "echo": "optional",
+              "flip": "optional",
+              "inversion": "required",
+              "part": "optional"
+            },
+            "suffixes": [
+              "MP2RAGE"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "anat"
+            ]
+          },
+          "anat_vfamt_common": {
+            "entities": {
+              "space": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "run": "optional",
+              "echo": "optional",
+              "flip": "required",
+              "mtransfer": "required",
+              "part": "optional"
+            },
+            "suffixes": [
+              "MPM",
+              "MTS"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "anat"
+            ]
+          },
+          "anat_mtr_common": {
+            "entities": {
+              "space": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "run": "optional",
+              "mtransfer": "required",
+              "part": "optional"
+            },
+            "suffixes": [
+              "MTR"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "anat"
+            ]
+          },
+          "beh_noncontinuous_common": {
+            "entities": {
+              "space": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "task": "required",
+              "acquisition": "optional",
+              "run": "optional"
+            },
+            "suffixes": [
+              "beh"
+            ],
+            "extensions": [
+              ".tsv",
+              ".json"
+            ],
+            "datatypes": [
+              "beh"
+            ]
+          },
+          "dwi_dwi_common": {
+            "entities": {
+              "space": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "reconstruction": "optional",
+              "direction": "optional",
+              "run": "optional",
+              "part": "optional"
+            },
+            "suffixes": [
+              "dwi"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json",
+              ".bvec",
+              ".bval"
+            ],
+            "datatypes": [
+              "dwi"
+            ]
+          },
+          "dwi_sbref_common": {
+            "entities": {
+              "space": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "reconstruction": "optional",
+              "direction": "optional",
+              "run": "optional",
+              "part": "optional"
+            },
+            "suffixes": [
+              "sbref"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "dwi"
+            ]
+          },
+          "eeg_eeg_common": {
+            "entities": {
+              "space": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "task": "required",
+              "acquisition": "optional",
+              "run": "optional"
+            },
+            "suffixes": [
+              "eeg"
+            ],
+            "extensions": [
+              ".json",
+              ".edf",
+              ".vhdr",
+              ".vmrk",
+              ".eeg",
+              ".set",
+              ".fdt",
+              ".bdf"
+            ],
+            "datatypes": [
+              "eeg"
+            ]
+          },
+          "fmap_fieldmaps_common": {
+            "entities": {
+              "space": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "run": "optional"
+            },
+            "suffixes": [
+              "phasediff",
+              "phase1",
+              "phase2",
+              "magnitude1",
+              "magnitude2",
+              "magnitude",
+              "fieldmap"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "fmap"
+            ]
+          },
+          "fmap_pepolar_common": {
+            "entities": {
+              "space": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "direction": "required",
+              "run": "optional"
+            },
+            "suffixes": [
+              "epi",
+              "m0scan"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "fmap"
+            ]
+          },
+          "fmap_TB1DAM_common": {
+            "entities": {
+              "space": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "run": "optional",
+              "flip": "required",
+              "inversion": "optional",
+              "part": "optional"
+            },
+            "suffixes": [
+              "TB1DAM"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "fmap"
+            ]
+          },
+          "fmap_TB1EPI_common": {
+            "entities": {
+              "space": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "run": "optional",
+              "echo": "required",
+              "flip": "required",
+              "inversion": "optional",
+              "part": "optional"
+            },
+            "suffixes": [
+              "TB1EPI"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "fmap"
+            ]
+          },
+          "fmap_RFFieldMaps_common": {
+            "entities": {
+              "space": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "run": "optional",
+              "echo": "optional",
+              "flip": "optional",
+              "inversion": "optional",
+              "part": "optional"
+            },
+            "suffixes": [
+              "TB1AFI",
+              "TB1TFL",
+              "TB1RFM",
+              "RB1COR"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "fmap"
+            ]
+          },
+          "fmap_TB1SRGE_common": {
+            "entities": {
+              "space": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "run": "optional",
+              "echo": "optional",
+              "flip": "required",
+              "inversion": "required",
+              "part": "optional"
+            },
+            "suffixes": [
+              "TB1SRGE"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "fmap"
+            ]
+          },
+          "fmap_parametric_common": {
+            "entities": {
+              "space": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "run": "optional"
+            },
+            "suffixes": [
+              "TB1map",
+              "RB1map"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "fmap"
+            ]
+          },
+          "func_func_common": {
+            "entities": {
+              "space": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "task": "required",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "direction": "optional",
+              "run": "optional",
+              "echo": "optional",
+              "part": "optional"
+            },
+            "suffixes": [
+              "bold",
+              "cbv",
+              "sbref"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "func"
+            ]
+          },
+          "func_phase_common": {
+            "entities": {
+              "space": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "task": "required",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "direction": "optional",
+              "run": "optional",
+              "echo": "optional"
+            },
+            "suffixes": [
+              "phase"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "func"
+            ]
+          },
+          "ieeg_ieeg_common": {
+            "entities": {
+              "space": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "task": "required",
+              "acquisition": "optional",
+              "run": "optional"
+            },
+            "suffixes": [
+              "ieeg"
+            ],
+            "extensions": [
+              ".mefd/",
+              ".json",
+              ".edf",
+              ".vhdr",
+              ".eeg",
+              ".vmrk",
+              ".set",
+              ".fdt",
+              ".nwb"
+            ],
+            "datatypes": [
+              "ieeg"
+            ]
+          },
+          "meg_meg_common": {
+            "entities": {
+              "space": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "task": "required",
+              "acquisition": "optional",
+              "run": "optional",
+              "processing": "optional",
+              "split": "optional"
+            },
+            "suffixes": [
+              "meg"
+            ],
+            "extensions": [
+              "/",
+              ".ds/",
+              ".json",
+              ".fif",
+              ".sqd",
+              ".con",
+              ".raw",
+              ".ave",
+              ".mrk",
+              ".kdf",
+              ".mhd",
+              ".trg",
+              ".chn"
+            ],
+            "datatypes": [
+              "meg"
+            ]
+          },
+          "meg_calibration_common": {
+            "entities": {
+              "space": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "acquisition": {
+                "level": "required",
+                "enum": [
+                  "calibration"
+                ]
+              }
+            },
+            "suffixes": [
+              "meg"
+            ],
+            "extensions": [
+              ".dat"
+            ],
+            "datatypes": [
+              "meg"
+            ]
+          },
+          "meg_crosstalk_common": {
+            "entities": {
+              "space": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "acquisition": {
+                "level": "required",
+                "enum": [
+                  "crosstalk"
+                ]
+              }
+            },
+            "suffixes": [
+              "meg"
+            ],
+            "extensions": [
+              ".fif"
+            ],
+            "datatypes": [
+              "meg"
+            ]
+          },
+          "meg_headshape_common": {
+            "entities": {
+              "space": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional"
+            },
+            "suffixes": [
+              "headshape"
+            ],
+            "extensions": [
+              ".*",
+              ".pos"
+            ],
+            "datatypes": [
+              "meg"
+            ]
+          },
+          "meg_markers_common": {
+            "entities": {
+              "space": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "task": "optional",
+              "acquisition": "optional"
+            },
+            "suffixes": [
+              "markers"
+            ],
+            "extensions": [
+              ".sqd",
+              ".mrk"
+            ],
+            "datatypes": [
+              "meg"
+            ]
+          },
+          "micr_microscopy_common": {
+            "entities": {
+              "space": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "sample": "required",
+              "acquisition": "optional",
+              "stain": "optional",
+              "run": "optional",
+              "chunk": "optional"
+            },
+            "suffixes": [
+              "TEM",
+              "SEM",
+              "uCT",
+              "BF",
+              "DF",
+              "PC",
+              "DIC",
+              "FLUO",
+              "CONF",
+              "PLI",
+              "CARS",
+              "2PE",
+              "MPE",
+              "SR",
+              "NLO",
+              "OCT",
+              "SPIM"
+            ],
+            "extensions": [
+              ".ome.tif",
+              ".ome.btf",
+              ".ome.zarr/",
+              ".png",
+              ".tif",
+              ".json"
+            ],
+            "datatypes": [
+              "micr"
+            ]
+          },
+          "perf_asl_common": {
+            "entities": {
+              "space": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "reconstruction": "optional",
+              "direction": "optional",
+              "run": "optional"
+            },
+            "suffixes": [
+              "asl",
+              "m0scan"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "perf"
+            ]
+          },
+          "pet_pet_common": {
+            "entities": {
+              "space": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "task": "optional",
+              "tracer": "optional",
+              "reconstruction": "optional",
+              "run": "optional"
+            },
+            "suffixes": [
+              "pet"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "pet"
+            ]
+          },
+          "pet_blood_common": {
+            "entities": {
+              "space": "optional",
+              "description": "optional",
+              "subject": "required",
+              "session": "optional",
+              "task": "optional",
+              "tracer": "optional",
+              "reconstruction": "optional",
+              "run": "optional",
+              "recording": "required"
+            },
+            "suffixes": [
+              "blood"
+            ],
+            "extensions": [
+              ".tsv",
+              ".json"
+            ],
+            "datatypes": [
+              "pet"
+            ]
+          }
+        }
+      },
+      "raw": {
+        "anat": {
+          "nonparametric": {
+            "suffixes": [
+              "T1w",
+              "T2w",
+              "PDw",
+              "T2starw",
+              "FLAIR",
+              "inplaneT1",
+              "inplaneT2",
+              "PDT2",
+              "angio",
+              "T2star",
+              "FLASH",
+              "PD"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "anat"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "run": "optional",
+              "part": "optional"
+            }
+          },
+          "parametric": {
+            "suffixes": [
+              "T1map",
+              "T2map",
+              "T2starmap",
+              "R1map",
+              "R2map",
+              "R2starmap",
+              "PDmap",
+              "MTRmap",
+              "MTsat",
+              "UNIT1",
+              "T1rho",
+              "MWFmap",
+              "MTVmap",
+              "PDT2map",
+              "Chimap",
+              "S0map",
+              "M0map"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "anat"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "run": "optional"
+            }
+          },
+          "defacemask": {
+            "suffixes": [
+              "defacemask"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "anat"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "run": "optional",
+              "modality": "optional"
+            }
+          },
+          "multiecho": {
+            "suffixes": [
+              "MESE",
+              "MEGRE"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "anat"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "run": "optional",
+              "echo": "required",
+              "part": "optional"
+            }
+          },
+          "multiflip": {
+            "suffixes": [
+              "VFA"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "anat"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "run": "optional",
+              "echo": "optional",
+              "flip": "required",
+              "part": "optional"
+            }
+          },
+          "multiinversion": {
+            "suffixes": [
+              "IRT1"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "anat"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "run": "optional",
+              "inversion": "required",
+              "part": "optional"
+            }
+          },
+          "mp2rage": {
+            "suffixes": [
+              "MP2RAGE"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "anat"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "run": "optional",
+              "echo": "optional",
+              "flip": "optional",
+              "inversion": "required",
+              "part": "optional"
+            }
+          },
+          "vfamt": {
+            "suffixes": [
+              "MPM",
+              "MTS"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "anat"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "run": "optional",
+              "echo": "optional",
+              "flip": "required",
+              "mtransfer": "required",
+              "part": "optional"
+            }
+          },
+          "mtr": {
+            "suffixes": [
+              "MTR"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "anat"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "run": "optional",
+              "mtransfer": "required",
+              "part": "optional"
+            }
+          }
+        },
+        "beh": {
+          "noncontinuous": {
+            "suffixes": [
+              "beh"
+            ],
+            "extensions": [
+              ".tsv",
+              ".json"
+            ],
+            "datatypes": [
+              "beh"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "task": "required",
+              "acquisition": "optional",
+              "run": "optional"
+            }
+          }
+        },
+        "channels": {
+          "channels": {
+            "suffixes": [
+              "channels"
+            ],
+            "extensions": [
+              ".json",
+              ".tsv"
+            ],
+            "datatypes": [
+              "eeg",
+              "ieeg",
+              "nirs"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "task": "required",
+              "acquisition": "optional",
+              "run": "optional"
+            }
+          },
+          "channels__meg": {
+            "datatypes": [
+              "meg"
+            ],
+            "entities": {
+              "processing": "optional",
+              "subject": "required",
+              "session": "optional",
+              "task": "required",
+              "acquisition": "optional",
+              "run": "optional"
+            },
+            "suffixes": [
+              "channels"
+            ],
+            "extensions": [
+              ".json",
+              ".tsv"
+            ]
+          },
+          "coordsystem": {
+            "suffixes": [
+              "coordsystem"
+            ],
+            "extensions": [
+              ".json"
+            ],
+            "datatypes": [
+              "meg",
+              "nirs"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional"
+            }
+          },
+          "coordsystem__eeg": {
+            "datatypes": [
+              "eeg",
+              "ieeg"
+            ],
+            "entities": {
+              "space": "optional",
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional"
+            },
+            "suffixes": [
+              "coordsystem"
+            ],
+            "extensions": [
+              ".json"
+            ]
+          },
+          "electrodes": {
+            "suffixes": [
+              "electrodes"
+            ],
+            "extensions": [
+              ".json",
+              ".tsv"
+            ],
+            "datatypes": [
+              "eeg",
+              "ieeg"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "space": "optional"
+            }
+          },
+          "optodes": {
+            "suffixes": [
+              "optodes"
+            ],
+            "extensions": [
+              ".tsv",
+              ".json"
+            ],
+            "datatypes": [
+              "nirs"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional"
+            }
+          }
+        },
+        "dwi": {
+          "dwi": {
+            "suffixes": [
+              "dwi"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json",
+              ".bvec",
+              ".bval"
+            ],
+            "datatypes": [
+              "dwi"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "reconstruction": "optional",
+              "direction": "optional",
+              "run": "optional",
+              "part": "optional"
+            }
+          },
+          "sbref": {
+            "suffixes": [
+              "sbref"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "dwi"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "reconstruction": "optional",
+              "direction": "optional",
+              "run": "optional",
+              "part": "optional"
+            }
+          }
+        },
+        "eeg": {
+          "eeg": {
+            "suffixes": [
+              "eeg"
+            ],
+            "extensions": [
+              ".json",
+              ".edf",
+              ".vhdr",
+              ".vmrk",
+              ".eeg",
+              ".set",
+              ".fdt",
+              ".bdf"
+            ],
+            "datatypes": [
+              "eeg"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "task": "required",
+              "acquisition": "optional",
+              "run": "optional"
+            }
+          }
+        },
+        "fmap": {
+          "fieldmaps": {
+            "suffixes": [
+              "phasediff",
+              "phase1",
+              "phase2",
+              "magnitude1",
+              "magnitude2",
+              "magnitude",
+              "fieldmap"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "fmap"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "run": "optional"
+            }
+          },
+          "pepolar": {
+            "suffixes": [
+              "epi",
+              "m0scan"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "fmap"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "direction": "required",
+              "run": "optional"
+            }
+          },
+          "TB1DAM": {
+            "suffixes": [
+              "TB1DAM"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "fmap"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "run": "optional",
+              "flip": "required",
+              "inversion": "optional",
+              "part": "optional"
+            }
+          },
+          "TB1EPI": {
+            "suffixes": [
+              "TB1EPI"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "fmap"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "run": "optional",
+              "echo": "required",
+              "flip": "required",
+              "inversion": "optional",
+              "part": "optional"
+            }
+          },
+          "RFFieldMaps": {
+            "suffixes": [
+              "TB1AFI",
+              "TB1TFL",
+              "TB1RFM",
+              "RB1COR"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "fmap"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "run": "optional",
+              "echo": "optional",
+              "flip": "optional",
+              "inversion": "optional",
+              "part": "optional"
+            }
+          },
+          "TB1SRGE": {
+            "suffixes": [
+              "TB1SRGE"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "fmap"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "run": "optional",
+              "echo": "optional",
+              "flip": "required",
+              "inversion": "required",
+              "part": "optional"
+            }
+          },
+          "parametric": {
+            "suffixes": [
+              "TB1map",
+              "RB1map"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "fmap"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "run": "optional"
+            }
+          }
+        },
+        "func": {
+          "func": {
+            "suffixes": [
+              "bold",
+              "cbv",
+              "sbref"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "func"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "task": "required",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "direction": "optional",
+              "run": "optional",
+              "echo": "optional",
+              "part": "optional"
+            }
+          },
+          "phase": {
+            "suffixes": [
+              "phase"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "func"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "task": "required",
+              "acquisition": "optional",
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "direction": "optional",
+              "run": "optional",
+              "echo": "optional"
+            }
+          }
+        },
+        "ieeg": {
+          "ieeg": {
+            "suffixes": [
+              "ieeg"
+            ],
+            "extensions": [
+              ".mefd/",
+              ".json",
+              ".edf",
+              ".vhdr",
+              ".eeg",
+              ".vmrk",
+              ".set",
+              ".fdt",
+              ".nwb"
+            ],
+            "datatypes": [
+              "ieeg"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "task": "required",
+              "acquisition": "optional",
+              "run": "optional"
+            }
+          }
+        },
+        "meg": {
+          "meg": {
+            "suffixes": [
+              "meg"
+            ],
+            "extensions": [
+              "/",
+              ".ds/",
+              ".json",
+              ".fif",
+              ".sqd",
+              ".con",
+              ".raw",
+              ".ave",
+              ".mrk",
+              ".kdf",
+              ".mhd",
+              ".trg",
+              ".chn"
+            ],
+            "datatypes": [
+              "meg"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "task": "required",
+              "acquisition": "optional",
+              "run": "optional",
+              "processing": "optional",
+              "split": "optional"
+            }
+          },
+          "calibration": {
+            "suffixes": [
+              "meg"
+            ],
+            "extensions": [
+              ".dat"
+            ],
+            "datatypes": [
+              "meg"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "acquisition": {
+                "level": "required",
+                "enum": [
+                  "calibration"
+                ]
+              }
+            }
+          },
+          "crosstalk": {
+            "suffixes": [
+              "meg"
+            ],
+            "extensions": [
+              ".fif"
+            ],
+            "datatypes": [
+              "meg"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "acquisition": {
+                "level": "required",
+                "enum": [
+                  "crosstalk"
+                ]
+              }
+            }
+          },
+          "headshape": {
+            "suffixes": [
+              "headshape"
+            ],
+            "extensions": [
+              ".*",
+              ".pos"
+            ],
+            "datatypes": [
+              "meg"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional"
+            }
+          },
+          "markers": {
+            "suffixes": [
+              "markers"
+            ],
+            "extensions": [
+              ".sqd",
+              ".mrk"
+            ],
+            "datatypes": [
+              "meg"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "task": "optional",
+              "acquisition": "optional",
+              "space": "optional"
+            }
+          }
+        },
+        "micr": {
+          "microscopy": {
+            "suffixes": [
+              "TEM",
+              "SEM",
+              "uCT",
+              "BF",
+              "DF",
+              "PC",
+              "DIC",
+              "FLUO",
+              "CONF",
+              "PLI",
+              "CARS",
+              "2PE",
+              "MPE",
+              "SR",
+              "NLO",
+              "OCT",
+              "SPIM"
+            ],
+            "extensions": [
+              ".ome.tif",
+              ".ome.btf",
+              ".ome.zarr/",
+              ".png",
+              ".tif",
+              ".json"
+            ],
+            "datatypes": [
+              "micr"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "sample": "required",
+              "acquisition": "optional",
+              "stain": "optional",
+              "run": "optional",
+              "chunk": "optional"
+            }
+          }
+        },
+        "nirs": {
+          "nirs": {
+            "suffixes": [
+              "nirs"
+            ],
+            "extensions": [
+              ".snirf",
+              ".json"
+            ],
+            "datatypes": [
+              "nirs"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "task": "required",
+              "acquisition": "optional",
+              "run": "optional"
+            }
+          }
+        },
+        "perf": {
+          "asl": {
+            "suffixes": [
+              "asl",
+              "m0scan"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "perf"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "reconstruction": "optional",
+              "direction": "optional",
+              "run": "optional"
+            }
+          },
+          "aslcontext": {
+            "suffixes": [
+              "aslcontext"
+            ],
+            "extensions": [
+              ".tsv",
+              ".json"
+            ],
+            "datatypes": [
+              "perf"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "reconstruction": "optional",
+              "direction": "optional",
+              "run": "optional"
+            }
+          },
+          "asllabeling": {
+            "suffixes": [
+              "asllabeling"
+            ],
+            "extensions": [
+              ".jpg"
+            ],
+            "datatypes": [
+              "perf"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional",
+              "reconstruction": "optional",
+              "run": "optional"
+            }
+          }
+        },
+        "pet": {
+          "pet": {
+            "suffixes": [
+              "pet"
+            ],
+            "extensions": [
+              ".nii.gz",
+              ".nii",
+              ".json"
+            ],
+            "datatypes": [
+              "pet"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "task": "optional",
+              "tracer": "optional",
+              "reconstruction": "optional",
+              "run": "optional"
+            }
+          },
+          "blood": {
+            "suffixes": [
+              "blood"
+            ],
+            "extensions": [
+              ".tsv",
+              ".json"
+            ],
+            "datatypes": [
+              "pet"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "task": "optional",
+              "tracer": "optional",
+              "reconstruction": "optional",
+              "run": "optional",
+              "recording": "required"
+            }
+          }
+        },
+        "photo": {
+          "photo": {
+            "suffixes": [
+              "photo"
+            ],
+            "extensions": [
+              ".jpg",
+              ".png",
+              ".tif"
+            ],
+            "datatypes": [
+              "eeg",
+              "ieeg",
+              "meg",
+              "nirs"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional"
+            }
+          },
+          "photo__micr": {
+            "extensions": [
+              ".jpg",
+              ".png",
+              ".tif",
+              ".json"
+            ],
+            "datatypes": [
+              "micr"
+            ],
+            "entities": {
+              "sample": "required",
+              "subject": "required",
+              "session": "optional",
+              "acquisition": "optional"
+            },
+            "suffixes": [
+              "photo"
+            ]
+          }
+        },
+        "task": {
+          "events": {
+            "suffixes": [
+              "events"
+            ],
+            "extensions": [
+              ".tsv",
+              ".json"
+            ],
+            "datatypes": [
+              "beh",
+              "eeg",
+              "ieeg",
+              "meg",
+              "nirs"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "task": "required",
+              "acquisition": "optional",
+              "run": "optional"
+            }
+          },
+          "timeseries": {
+            "suffixes": [
+              "physio",
+              "stim"
+            ],
+            "extensions": [
+              ".tsv.gz",
+              ".json"
+            ],
+            "datatypes": [
+              "beh",
+              "eeg",
+              "ieeg",
+              "meg",
+              "nirs"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "task": "required",
+              "acquisition": "optional",
+              "run": "optional",
+              "recording": "optional"
+            }
+          },
+          "events__mri": {
+            "datatypes": [
+              "func"
+            ],
+            "entities": {
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "direction": "optional",
+              "subject": "required",
+              "session": "optional",
+              "task": "required",
+              "acquisition": "optional",
+              "run": "optional"
+            },
+            "suffixes": [
+              "events"
+            ],
+            "extensions": [
+              ".tsv",
+              ".json"
+            ]
+          },
+          "events__pet": {
+            "datatypes": [
+              "pet"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "task": "required",
+              "tracer": "optional",
+              "reconstruction": "optional",
+              "run": "optional"
+            },
+            "suffixes": [
+              "events"
+            ],
+            "extensions": [
+              ".tsv",
+              ".json"
+            ]
+          },
+          "timeseries__mri": {
+            "datatypes": [
+              "dwi",
+              "perf"
+            ],
+            "entities": {
+              "reconstruction": "optional",
+              "direction": "optional",
+              "subject": "required",
+              "session": "optional",
+              "task": "required",
+              "acquisition": "optional",
+              "run": "optional",
+              "recording": "optional"
+            },
+            "suffixes": [
+              "physio",
+              "stim"
+            ],
+            "extensions": [
+              ".tsv.gz",
+              ".json"
+            ]
+          },
+          "timeseries__func": {
+            "datatypes": [
+              "func"
+            ],
+            "entities": {
+              "ceagent": "optional",
+              "reconstruction": "optional",
+              "direction": "optional",
+              "subject": "required",
+              "session": "optional",
+              "task": "required",
+              "acquisition": "optional",
+              "run": "optional",
+              "recording": "optional"
+            },
+            "suffixes": [
+              "physio",
+              "stim"
+            ],
+            "extensions": [
+              ".tsv.gz",
+              ".json"
+            ]
+          },
+          "timeseries__pet": {
+            "datatypes": [
+              "pet"
+            ],
+            "entities": {
+              "subject": "required",
+              "session": "optional",
+              "task": "required",
+              "tracer": "optional",
+              "reconstruction": "optional",
+              "run": "optional",
+              "recording": "optional"
+            },
+            "suffixes": [
+              "physio",
+              "stim"
+            ],
+            "extensions": [
+              ".tsv.gz",
+              ".json"
+            ]
+          }
+        }
+      }
+    },
+    "modalities": {
+      "mri": {
+        "datatypes": [
+          "anat",
+          "dwi",
+          "fmap",
+          "func",
+          "perf"
+        ]
+      },
+      "eeg": {
+        "datatypes": [
+          "eeg"
+        ]
+      },
+      "ieeg": {
+        "datatypes": [
+          "ieeg"
+        ]
+      },
+      "meg": {
+        "datatypes": [
+          "meg"
+        ]
+      },
+      "beh": {
+        "datatypes": [
+          "beh"
+        ]
+      },
+      "pet": {
+        "datatypes": [
+          "pet"
+        ]
+      },
+      "micr": {
+        "datatypes": [
+          "micr"
+        ]
+      },
+      "nirs": {
+        "datatypes": [
+          "nirs"
+        ]
+      }
+    },
+    "sidecars": {
+      "anat": {
+        "MRIAnatomyCommonMetadataFields": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"anat\""
+          ],
+          "fields": {
+            "ContrastBolusIngredient": "optional",
+            "RepetitionTimeExcitation": "optional",
+            "RepetitionTimePreparation": "optional"
+          }
+        },
+        "PhaseEntityUnits": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"anat\"",
+            "entities.part == \"phase\""
+          ],
+          "fields": {
+            "Units": "required"
+          }
+        },
+        "PhaseSuffixUnits": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"anat\"",
+            "suffix == \"phase\""
+          ],
+          "fields": {
+            "Units": "required"
+          }
+        }
+      },
+      "asl": {
+        "MRIASLTextOnly": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"perf\"",
+            "intersects([suffix], [\"asl\", \"m0scan\"])"
+          ],
+          "fields": {
+            "RepetitionTimePreparation": "required"
+          }
+        },
+        "MRIASLCommonMetadataFields": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"perf\"",
+            "suffix == \"asl\""
+          ],
+          "fields": {
+            "ArterialSpinLabelingType": "required",
+            "PostLabelingDelay": "required",
+            "BackgroundSuppression": "required",
+            "M0Type": "required",
+            "TotalAcquiredPairs": "required",
+            "VascularCrushing": "recommended",
+            "AcquisitionVoxelSize": "recommended",
+            "LabelingOrientation": "recommended",
+            "LabelingDistance": "recommended",
+            "LabelingLocationDescription": "recommended",
+            "LookLocker": "optional",
+            "LabelingEfficiency": "optional"
+          }
+        },
+        "MRIASLCommonMetadataFieldsM0TypeRec": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"perf\"",
+            "suffix == \"asl\"",
+            "sidecar.M0Type != \"Estimate\""
+          ],
+          "fields": {
+            "M0Estimate": {
+              "level": "optional",
+              "level_addendum": "required if `M0Type` is `Estimate`"
+            }
+          }
+        },
+        "MRIASLCommonMetadataFieldsM0TypeReq": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"perf\"",
+            "suffix == \"asl\"",
+            "sidecar.M0Type == \"Estimate\""
+          ],
+          "fields": {
+            "M0Estimate": {
+              "level": "required",
+              "issue": {
+                "code": "M0ESTIMATE_NOT_DEFINED",
+                "message": "You must define `M0Estimate` for this file, because `M0Type` is set to\n'Estimate'. `M0Estimate` is a single numerical whole-brain M0 value\n(referring to the M0 of blood), only if obtained externally (for example\nretrieved from CSF in a separate measurement).\n"
+              }
+            }
+          }
+        },
+        "MRIASLCommonMetadataFieldsBackgroundSuppressionOpt": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"perf\"",
+            "suffix == \"asl\"",
+            "sidecar.BackgroundSuppression == false"
+          ],
+          "fields": {
+            "BackgroundSuppressionNumberPulses": {
+              "level": "optional",
+              "level_addendum": "recommended if `BackgroundSuppression` is `true`"
+            },
+            "BackgroundSuppressionPulseTime": {
+              "level": "optional",
+              "level_addendum": "recommended if `BackgroundSuppression` is `true`"
+            }
+          }
+        },
+        "MRIASLCommonMetadataFieldsBackgroundSuppressionReq": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"perf\"",
+            "suffix == \"asl\"",
+            "sidecar.BackgroundSuppression == true"
+          ],
+          "fields": {
+            "BackgroundSuppressionNumberPulses": "recommended",
+            "BackgroundSuppressionPulseTime": "recommended"
+          }
+        },
+        "MRIASLCommonMetadataFieldsVascularCrushingOpt": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"perf\"",
+            "suffix == \"asl\"",
+            "sidecar.VascularCrushing == false"
+          ],
+          "fields": {
+            "VascularCrushingVENC": {
+              "level": "optional",
+              "level_addendum": "recommended if `VascularCrushing` is `true`"
+            }
+          }
+        },
+        "MRIASLCommonMetadataFieldsVascularCrushingRec": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"perf\"",
+            "suffix == \"asl\"",
+            "sidecar.VascularCrushing == true"
+          ],
+          "fields": {
+            "VascularCrushingVENC": "recommended"
+          }
+        },
+        "MRIASLCaslPcaslSpecific": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"perf\"",
+            "suffix == \"asl\"",
+            "intersects([sidecar.ArterialSpinLabelingType], [\"CASL\", \"PCASL\"])"
+          ],
+          "fields": {
+            "LabelingDuration": "required",
+            "LabelingPulseAverageGradient": "recommended",
+            "LabelingPulseMaximumGradient": "recommended",
+            "LabelingPulseAverageB1": "recommended",
+            "LabelingPulseDuration": "recommended",
+            "LabelingPulseFlipAngle": "recommended",
+            "LabelingPulseInterval": "recommended"
+          }
+        },
+        "MRIASLPcaslSpecific": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"perf\"",
+            "suffix == \"asl\"",
+            "sidecar.ArterialSpinLabelingType == \"PCASL\""
+          ],
+          "fields": {
+            "PCASLType": {
+              "level": "recommended",
+              "level_addendum": "if `ArterialSpinLabelingType` is `\"PCASL\"`"
+            }
+          }
+        },
+        "MRIASLCaslSpecific": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"perf\"",
+            "suffix == \"asl\"",
+            "sidecar.ArterialSpinLabelingType == \"CASL\""
+          ],
+          "fields": {
+            "CASLType": {
+              "level": "recommended",
+              "level_addendum": "if `ArterialSpinLabelingType` is `\"CASL\"`"
+            }
+          }
+        },
+        "MRIASLPaslSpecific": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"perf\"",
+            "suffix == \"asl\"",
+            "sidecar.ArterialSpinLabelingType == \"PASL\""
+          ],
+          "fields": {
+            "BolusCutOffFlag": "required",
+            "PASLType": "recommended",
+            "LabelingSlabThickness": "recommended"
+          }
+        },
+        "MRIASLPASLSpecificBolusCutOffFlagFalse": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"perf\"",
+            "suffix == \"asl\"",
+            "sidecar.ArterialSpinLabelingType == \"PASL\"",
+            "sidecar.BolusCutOffFlag == false"
+          ],
+          "fields": {
+            "BolusCutOffDelayTime": {
+              "level": "optional",
+              "level_addendum": "required if `BolusCutOffFlag` is `true`"
+            },
+            "BolusCutOffTechnique": {
+              "level": "optional",
+              "level_addendum": "required if `BolusCutOffFlag` is `true`"
+            }
+          }
+        },
+        "MRIASLPaslSpecificBolusCutOffFlagTrue": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"perf\"",
+            "suffix == \"asl\"",
+            "sidecar.ArterialSpinLabelingType == \"PASL\"",
+            "sidecar.BolusCutOffFlag == true"
+          ],
+          "fields": {
+            "BolusCutOffDelayTime": {
+              "level": "required",
+              "issue": {
+                "code": "PASL_BOLUS_CUT_OFF_DELAY_TIME",
+                "message": "It is required to define 'BolusCutOffDelayTime' for this file,\nwhen 'BolusCutOffFlag' is set to true. 'BolusCutOffDelayTime' is\nthe duration between the end of the labeling and the start of the\nbolus cut-off saturation pulse(s), in seconds. This can be a number\nor array of numbers, of which the values must be non-negative and\nmonotonically increasing, depending on the number of bolus cut-off\nsaturation pulses. For Q2TIPS, only the values for the first and last\nbolus cut-off saturation pulses are provided. Based on DICOM Tag\n0018,925F ASL Bolus Cut-off Delay Time.\n"
+              }
+            },
+            "BolusCutOffTechnique": {
+              "level": "required",
+              "issue": {
+                "code": "PASL_BOLUS_CUT_OFF_TECHINIQUE",
+                "message": "It is required to define `BolusCutOffTechnique` for this file,\nwhen `BolusCutOffFlag` is set to `true`. `BolusCutOffTechnique`,\nis the name of the technique used\n(for example, Q2TIPS, QUIPSS or QUIPSSII).\nCorresponds to DICOM Tag 0018,925E `ASL Bolus Cut-off Technique`.\n"
+              }
+            }
+          }
+        },
+        "MRIASLM0Scan": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"perf\"",
+            "suffix == \"m0scan\""
+          ],
+          "fields": {
+            "IntendedFor": {
+              "level": "required",
+              "description_addendum": "This is used to refer to the ASL time series for which the `*_m0scan.nii[.gz]` is intended.\n"
+            },
+            "AcquisitionVoxelSize": "recommended"
+          }
+        }
+      },
+      "beh": {
+        "BEHTabularData": {
+          "selectors": [
+            "intersects([suffix], [\"beh\", \"events\"])"
+          ],
+          "fields": {
+            "TaskName": "recommended",
+            "Instructions": "recommended",
+            "TaskDescription": "recommended",
+            "CogAtlasID": "recommended",
+            "CogPOID": "recommended",
+            "InstitutionName": "recommended",
+            "InstitutionAddress": "recommended",
+            "InstitutionalDepartmentName": "recommended"
+          }
+        }
+      },
+      "continuous": {
+        "Continuous": {
+          "selectors": [
+            "intersects([suffix], [\"physio\", \"stim\"])"
+          ],
+          "fields": {
+            "SamplingFrequency": "required",
+            "StartTime": "required",
+            "Columns": "required"
+          }
+        },
+        "Physio": {
+          "selectors": [
+            "suffix == \"physio\""
+          ],
+          "fields": {
+            "Manufacturer": "recommended",
+            "ManufacturersModelName": "recommended",
+            "SoftwareVersions": "recommended",
+            "DeviceSerialNumber": "recommended"
+          }
+        }
+      },
+      "derivatives": {
+        "common_derivatives": {
+          "CommonDerivativeFields": {
+            "selectors": [
+              "dataset.dataset_description.DatasetType == \"derivative\""
+            ],
+            "fields": {
+              "Description": {
+                "level": "recommended",
+                "description_addendum": "This describes the nature of the file."
+              },
+              "Sources": "optional",
+              "RawSources": "deprecated"
+            }
+          },
+          "SpatialReferenceEntity": {
+            "selectors": [
+              "dataset.dataset_description.DatasetType == \"derivative\"",
+              "\"space\" in entities"
+            ],
+            "fields": {
+              "SpatialReference": {
+                "level": "recommended",
+                "level_addendum": "if the derivative is aligned to a standard template listed in\n[Standard template identifiers][templates]. Required otherwise.\n"
+              }
+            }
+          },
+          "SpatialReferenceNonStandard": {
+            "selectors": [
+              "dataset.dataset_description.DatasetType == \"derivative\"",
+              "!intersects(schema.objects.metadata._StandardTemplateCoordSys, [entities.space])"
+            ],
+            "fields": {
+              "SpatialReference": "required"
+            }
+          },
+          "SpatialReferenceNoEntity": {
+            "selectors": [
+              "dataset.dataset_description.DatasetType == \"derivative\"",
+              "!(\"space\" in entities)"
+            ],
+            "fields": {
+              "SpatialReference": "required"
+            }
+          },
+          "MaskDerivatives": {
+            "selectors": [
+              "dataset.dataset_description.DatasetType == \"derivative\"",
+              "suffix == \"mask\""
+            ],
+            "fields": {
+              "Type": "recommended",
+              "Sources": "recommended",
+              "RawSources": "deprecated"
+            }
+          },
+          "MaskDerivativesAtlas": {
+            "selectors": [
+              "dataset.dataset_description.DatasetType == \"derivative\"",
+              "suffix == \"mask\"",
+              "\"label\" in entities"
+            ],
+            "fields": {
+              "Atlas": {
+                "level": "recommended",
+                "level_addendum": "if `label` entity is defined"
+              }
+            }
+          },
+          "SegmentationCommon": {
+            "selectors": [
+              "dataset.dataset_description.DatasetType == \"derivative\"",
+              "intersects([suffix], [\"dseg\", \"probseg\"])"
+            ],
+            "fields": {
+              "Manual": "optional"
+            }
+          },
+          "SegmentationCommonAtlas": {
+            "selectors": [
+              "dataset.dataset_description.DatasetType == \"derivative\"",
+              "intersects([suffix], [\"dseg\", \"probseg\"])",
+              "\"atlas\" in entities"
+            ],
+            "fields": {
+              "Atlas": {
+                "level": "recommended",
+                "level_addendum": "if `atlas` is present"
+              }
+            }
+          },
+          "ImageDerivatives": {
+            "selectors": [
+              "dataset.dataset_description.DatasetType == \"derivative\"",
+              "intersects([modality], [\"mri\", \"pet\"])",
+              "match(extension, \"^\\.nii(\\.gz)?$\")"
+            ],
+            "fields": {
+              "SkullStripped": "required"
+            }
+          },
+          "ImageDerivativeResEntity": {
+            "selectors": [
+              "dataset.dataset_description.DatasetType == \"derivative\"",
+              "intersects([modality], [\"mri\", \"pet\"])",
+              "\"res\" in entities"
+            ],
+            "fields": {
+              "Resolution": {
+                "level": "required",
+                "level_addendum": "if `res` is present"
+              }
+            }
+          },
+          "ImageDerivativeDenEntity": {
+            "selectors": [
+              "dataset.dataset_description.DatasetType == \"derivative\"",
+              "intersects([modality], [\"mri\", \"pet\"])",
+              "\"den\" in entities"
+            ],
+            "fields": {
+              "Density": {
+                "level": "required",
+                "level_addendum": "if `den` is present"
+              }
+            }
+          }
+        }
+      },
+      "dwi": {
+        "MRIDiffusionMultipart": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"dwi\""
+          ],
+          "fields": {
+            "MultipartID": "required"
+          }
+        },
+        "MRIDiffusionOtherMetadata": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"dwi\""
+          ],
+          "fields": {
+            "PhaseEncodingDirection": "recommended",
+            "TotalReadoutTime": "recommended"
+          }
+        }
+      },
+      "eeg": {
+        "EEGGeneric": {
+          "selectors": [
+            "modality == \"eeg\"",
+            "datatype == \"eeg\"",
+            "suffix == \"eeg\""
+          ],
+          "fields": {
+            "TaskName": {
+              "level": "required",
+              "description_addendum": "A recommended convention is to name resting state task using labels\nbeginning with `rest`.\n"
+            }
+          }
+        },
+        "EEGRecommended": {
+          "selectors": [
+            "modality == \"eeg\"",
+            "datatype == \"eeg\"",
+            "suffix == \"eeg\""
+          ],
+          "fields": {
+            "InstitutionName": "recommended",
+            "InstitutionAddress": "recommended",
+            "InstitutionalDepartmentName": "recommended",
+            "Manufacturer": "recommended",
+            "ManufacturersModelName": "recommended",
+            "SoftwareVersions": "recommended",
+            "TaskDescription": "recommended",
+            "Instructions": {
+              "level": "recommended",
+              "description_addendum": "This is especially important in context of resting state recordings and\ndistinguishing between eyes open and eyes closed paradigms.\n"
+            },
+            "CogAtlasID": "recommended",
+            "CogPOID": "recommended",
+            "DeviceSerialNumber": "recommended"
+          }
+        },
+        "EEGRequired": {
+          "selectors": [
+            "modality == \"eeg\"",
+            "datatype == \"eeg\"",
+            "suffix == \"eeg\""
+          ],
+          "fields": {
+            "EEGReference": "required",
+            "SamplingFrequency": {
+              "level": "required",
+              "description_addendum": "The sampling frequency of data channels that deviate from the main sampling\nfrequency SHOULD be specified in the `channels.tsv` file.\n"
+            },
+            "PowerLineFrequency": "required",
+            "SoftwareFilters": "required"
+          }
+        },
+        "EEGMoreRecommended": {
+          "selectors": [
+            "modality == \"eeg\"",
+            "datatype == \"eeg\"",
+            "suffix == \"eeg\""
+          ],
+          "fields": {
+            "CapManufacturer": "recommended",
+            "CapManufacturersModelName": "recommended",
+            "EEGChannelCount": "recommended",
+            "ECGChannelCount": "recommended",
+            "EMGChannelCount": "recommended",
+            "EOGChannelCount": "recommended",
+            "MiscChannelCount": "recommended",
+            "TriggerChannelCount": "recommended",
+            "RecordingDuration": "recommended",
+            "RecordingType": "recommended",
+            "EpochLength": "recommended",
+            "EEGGround": "recommended",
+            "HeadCircumference": "recommended",
+            "EEGPlacementScheme": "recommended",
+            "HardwareFilters": "recommended",
+            "SubjectArtefactDescription": "recommended"
+          }
+        },
+        "EEGCoordsystemGeneral": {
+          "selectors": [
+            "modality == \"eeg\"",
+            "datatype == \"eeg\"",
+            "suffix == \"coordsystem\""
+          ],
+          "fields": {
+            "IntendedFor": {
+              "level": "optional",
+              "description_addendum": "This identifies the MRI or CT scan associated with the electrodes,\nlandmarks, and fiducials.\n"
+            }
+          }
+        },
+        "EEGCoordsystemPositions": {
+          "selectors": [
+            "modality == \"eeg\"",
+            "datatype == \"eeg\"",
+            "suffix == \"coordsystem\""
+          ],
+          "fields": {
+            "EEGCoordinateSystem": "required",
+            "EEGCoordinateUnits": "required",
+            "EEGCoordinateSystemDescription": {
+              "level": "recommended",
+              "level_addendum": "required if `EEGCoordinateSystem` is `\"Other\"`"
+            }
+          }
+        },
+        "EEGCoordsystemOther": {
+          "selectors": [
+            "modality == \"eeg\"",
+            "datatype == \"eeg\"",
+            "suffix == \"coordsystem\"",
+            "\"EEGCoordinateSystem\" in sidecar",
+            "sidecar.EEGCoordinateSystem == \"Other\""
+          ],
+          "fields": {
+            "EEGCoordinateSystemDescription": "required"
+          }
+        },
+        "EEGCoordsystemFiducials": {
+          "selectors": [
+            "modality == \"eeg\"",
+            "datatype == \"eeg\"",
+            "suffix == \"coordsystem\""
+          ],
+          "fields": {
+            "FiducialsDescription": "optional",
+            "FiducialsCoordinates": "recommended",
+            "FiducialsCoordinateSystem": "recommended",
+            "FiducialsCoordinateUnits": "recommended",
+            "FiducialsCoordinateSystemDescription": {
+              "level": "recommended",
+              "level_addendum": "required if `FiducialsCoordinateSystem` is `\"Other\"`"
+            }
+          }
+        },
+        "EEGCoordsystemOtherFiducialCoordinateSystem": {
+          "selectors": [
+            "modality == \"eeg\"",
+            "datatype == \"eeg\"",
+            "suffix == \"coordsystem\"",
+            "sidecar.FiducialsCoordinateSystem == \"Other\""
+          ],
+          "fields": {
+            "FiducialsCoordinateSystemDescription": "required"
+          }
+        },
+        "EEGCoordsystemLandmark": {
+          "selectors": [
+            "modality == \"eeg\"",
+            "datatype == \"eeg\"",
+            "suffix == \"coordsystem\""
+          ],
+          "fields": {
+            "AnatomicalLandmarkCoordinates": "recommended",
+            "AnatomicalLandmarkCoordinateSystem": {
+              "level": "recommended",
+              "description_addendum": "Preferably the same as the `EEGCoordinateSystem`."
+            },
+            "AnatomicalLandmarkCoordinateUnits": "recommended"
+          }
+        },
+        "EEGCoordsystemLandmarkDescriptionRec": {
+          "selectors": [
+            "modality == \"eeg\"",
+            "datatype == \"eeg\"",
+            "suffix == \"coordsystem\"",
+            "sidecar.AnatomicalLandmarkCoordinateSystem != \"Other\""
+          ],
+          "fields": {
+            "AnatomicalLandmarkCoordinateSystemDescription": {
+              "level": "recommended",
+              "level_addendum": "required if `AnatomicalLandmarkCoordinateSystem` is `\"Other\"`"
+            }
+          }
+        },
+        "EEGCoordsystemLandmarkDescriptionReq": {
+          "selectors": [
+            "modality == \"eeg\"",
+            "datatype == \"eeg\"",
+            "suffix == \"coordsystem\"",
+            "sidecar.AnatomicalLandmarkCoordinateSystem == \"Other\""
+          ],
+          "fields": {
+            "AnatomicalLandmarkCoordinateSystemDescription": "required"
+          }
+        }
+      },
+      "entity_rules": {
+        "EntitiesTaskMetadata": {
+          "selectors": [
+            "\"task\" in entities"
+          ],
+          "fields": {
+            "TaskName": "recommended"
+          }
+        },
+        "EntitiesCeMetadata": {
+          "selectors": [
+            "\"ce\" in entities"
+          ],
+          "fields": {
+            "ContrastBolusIngredient": "optional"
+          }
+        },
+        "EntitiesTrcMetadata": {
+          "selectors": [
+            "\"trc\" in entities"
+          ],
+          "fields": {
+            "TracerName": "required"
+          }
+        },
+        "EntitiesStainMetadata": {
+          "selectors": [
+            "\"stain\" in entities"
+          ],
+          "fields": {
+            "SampleStaining": "recommended",
+            "SamplePrimaryAntibody": "recommended",
+            "SampleSecondaryAntibody": "recommended"
+          }
+        },
+        "EntitiesEchoMetadata": {
+          "selectors": [
+            "\"echo\" in entities"
+          ],
+          "fields": {
+            "EchoTime": "required"
+          }
+        },
+        "EntitiesFlipMetadata": {
+          "selectors": [
+            "\"flip\" in entities"
+          ],
+          "fields": {
+            "FlipAngle": "required"
+          }
+        },
+        "EntitiesInvMetadata": {
+          "selectors": [
+            "\"inv\" in entities"
+          ],
+          "fields": {
+            "InversionTime": "required"
+          }
+        },
+        "EntitiesMTMetadata": {
+          "selectors": [
+            "\"mt\" in entities"
+          ],
+          "fields": {
+            "MTState": "required"
+          }
+        },
+        "EntitiesPartMetadata": {
+          "selectors": [
+            "entities.part == \"phase\""
+          ],
+          "fields": {
+            "Units": "required"
+          }
+        },
+        "EntitiesResMetadata": {
+          "selectors": [
+            "\"res\" in entities"
+          ],
+          "fields": {
+            "Resolution": "required"
+          }
+        },
+        "EntitiesDenMetadata": {
+          "selectors": [
+            "\"den\" in entities"
+          ],
+          "fields": {
+            "Density": "required"
+          }
+        }
+      },
+      "events": {
+        "StimulusPresentation": {
+          "selectors": [
+            "suffix == \"events\""
+          ],
+          "fields": {
+            "StimulusPresentation": "recommended"
+          }
+        }
+      },
+      "fmap": {
+        "MRIFieldmapB0FieldIdentifier": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"fmap\""
+          ],
+          "fields": {
+            "B0FieldIdentifier": "recommended"
+          }
+        },
+        "MRIFieldmapIntendedFor": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"fmap\""
+          ],
+          "fields": {
+            "IntendedFor": {
+              "level": "optional",
+              "description_addendum": "This field is optional, and in case the fieldmaps do not correspond\nto any particular scans, it does not have to be filled.\n"
+            }
+          }
+        },
+        "MRIFieldmapPhaseDifferencePhasediff": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"fmap\"",
+            "suffix == \"phasediff\""
+          ],
+          "fields": {
+            "EchoTime1": "required",
+            "EchoTime2": "required"
+          }
+        },
+        "MRIFieldmapPhaseDifferenceMagnitude1": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"fmap\"",
+            "suffix == \"magnitude1\""
+          ],
+          "fields": {
+            "EchoTime1": "required"
+          }
+        },
+        "MRIFieldmapPhaseDifferenceMagnitude2": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"fmap\"",
+            "suffix == \"magnitude2\""
+          ],
+          "fields": {
+            "EchoTime2": "required"
+          }
+        },
+        "MRIFieldmapTwoPhase": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"fmap\"",
+            "intersects([suffix], [\"phase1\", \"phase2\", \"magnitude1\", \"magnitude2\"])"
+          ],
+          "fields": {
+            "EchoTime__fmap": "required"
+          }
+        },
+        "MRIFieldmapDirectFieldMapping": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"fmap\"",
+            "intersects([suffix], [\"phase\", \"fieldmap\"])"
+          ],
+          "fields": {
+            "Units": {
+              "level": "required",
+              "description_addendum": "Fieldmaps must be in units of Hertz (`\"Hz\"`),\nradians per second (`\"rad/s\"`), or Tesla (`\"T\"`).\n"
+            }
+          }
+        },
+        "MRIFieldmapPepolar": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"fmap\"",
+            "suffix == \"epi\""
+          ],
+          "fields": {
+            "PhaseEncodingDirection": "required",
+            "TotalReadoutTime": "required"
+          }
+        }
+      },
+      "func": {
+        "MRIFuncRequired": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"func\"",
+            "match(extension, \"^\\.nii(\\.gz)?$\")"
+          ],
+          "fields": {
+            "TaskName": {
+              "level": "required",
+              "description_addendum": "A recommended convention is to name resting state task using labels\nbeginning with `rest`.\n"
+            }
+          }
+        },
+        "MRIFuncRepetitionTime": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"func\"",
+            "!(\"VolumeTiming\" in sidecar)",
+            "match(extension, \"^\\.nii(\\.gz)?$\")"
+          ],
+          "fields": {
+            "RepetitionTime": {
+              "level": "required",
+              "level_addendum": "mutually exclusive with `VolumeTiming`"
+            }
+          }
+        },
+        "MRIFuncVolumeTiming": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"func\"",
+            "!(\"RepetitionTime\" in sidecar)",
+            "match(extension, \"^\\.nii(\\.gz)?$\")"
+          ],
+          "fields": {
+            "VolumeTiming": {
+              "level": "required",
+              "level_addendum": "mutually exclusive with `RepetitionTime`"
+            }
+          }
+        },
+        "MRIFuncTimingParameters": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"func\""
+          ],
+          "fields": {
+            "NumberOfVolumesDiscardedByScanner": "recommended",
+            "NumberOfVolumesDiscardedByUser": "recommended",
+            "DelayTime": "recommended",
+            "AcquisitionDuration": {
+              "level": "recommended",
+              "level_addendum": "required for sequences that are described with the `VolumeTiming`\nfield and that do not have the `SliceTiming` field set to allow for\naccurate calculation of \"acquisition time\"\n",
+              "issue": {
+                "name": "VOLUME_TIMING_MISSING_ACQUISITION_DURATION",
+                "message": "The field 'VolumeTiming' requires 'AcquisitionDuration' or 'SliceTiming' to be defined.\n"
+              }
+            },
+            "DelayAfterTrigger": "recommended"
+          }
+        },
+        "MRIFuncTimingParametersMutualExclusion1": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"func\"",
+            "\"RepetitionTime\" in sidecar"
+          ],
+          "fields": {
+            "AcquisitionDuration": "prohibited",
+            "VolumeTiming": "prohibited"
+          }
+        },
+        "MRIFuncTimingParametersMutualExclusion2": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"func\"",
+            "\"SliceTiming\" in sidecar",
+            "\"VolumeTiming\" in sidecar"
+          ],
+          "fields": {
+            "RepetitionTime": "prohibited",
+            "DelayTime": "prohibited"
+          }
+        },
+        "MRIFuncTimingParametersMutualExclusion3": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"func\"",
+            "\"AcquisitionDuration\" in sidecar",
+            "\"VolumeTiming\" in sidecar"
+          ],
+          "fields": {
+            "RepetitionTime": "prohibited",
+            "DelayTime": "prohibited"
+          }
+        },
+        "MRIFuncTimingParametersMutualExclusion4": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"func\"",
+            "\"RepetitionTime\" in sidecar",
+            "\"SliceTiming\" in sidecar"
+          ],
+          "fields": {
+            "AcquisitionDuration": "prohibited",
+            "VolumeTiming": "prohibited"
+          }
+        },
+        "MRIFuncTimingParametersMutualExclusion5": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"func\"",
+            "\"RepetitionTime\" in sidecar",
+            "\"DelayTime\" in sidecar"
+          ],
+          "fields": {
+            "AcquisitionDuration": "prohibited",
+            "VolumeTiming": "prohibited"
+          }
+        },
+        "MRIFuncTaskInformation": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"func\""
+          ],
+          "fields": {
+            "Instructions": {
+              "level": "recommended",
+              "description_addendum": "This is especially important in context of resting state recordings and\ndistinguishing between eyes open and eyes closed paradigms.\n"
+            },
+            "TaskDescription": "recommended",
+            "CogAtlasID": "recommended",
+            "CogPOID": "recommended"
+          }
+        }
+      },
+      "ieeg": {
+        "iEEGGeneric": {
+          "selectors": [
+            "modality == \"ieeg\"",
+            "datatype == \"ieeg\"",
+            "suffix == \"ieeg\""
+          ],
+          "fields": {
+            "TaskName": {
+              "level": "required",
+              "description_addendum": "A recommended convention is to name resting state task using labels\nbeginning with `rest`.\n"
+            }
+          }
+        },
+        "iEEGRecommended": {
+          "selectors": [
+            "modality == \"ieeg\"",
+            "datatype == \"ieeg\"",
+            "suffix == \"ieeg\""
+          ],
+          "fields": {
+            "InstitutionName": "recommended",
+            "InstitutionAddress": "recommended",
+            "InstitutionalDepartmentName": "recommended",
+            "Manufacturer": {
+              "level": "recommended",
+              "description_addendum": "For example, `\"TDT\"`, `\"Blackrock\"`."
+            },
+            "ManufacturersModelName": "recommended",
+            "SoftwareVersions": "recommended",
+            "TaskDescription": "recommended",
+            "Instructions": {
+              "level": "recommended",
+              "description_addendum": "This is especially important in context of resting state recordings and\ndistinguishing between eyes open and eyes closed paradigms.\n"
+            },
+            "CogAtlasID": "recommended",
+            "CogPOID": "recommended",
+            "DeviceSerialNumber": "recommended"
+          }
+        },
+        "iEEGRequired": {
+          "selectors": [
+            "modality == \"ieeg\"",
+            "datatype == \"ieeg\"",
+            "suffix == \"ieeg\""
+          ],
+          "fields": {
+            "iEEGReference": "required",
+            "SamplingFrequency": {
+              "level": "required",
+              "description_addendum": "The sampling frequency of data channels that deviate from the main sampling\nfrequency SHOULD be specified in the `channels.tsv` file.\n"
+            },
+            "PowerLineFrequency": "required",
+            "SoftwareFilters": "required"
+          }
+        },
+        "iEEGMoreRecommended": {
+          "selectors": [
+            "modality == \"ieeg\"",
+            "datatype == \"ieeg\"",
+            "suffix == \"ieeg\""
+          ],
+          "fields": {
+            "DCOffsetCorrection": "deprecated",
+            "HardwareFilters": "recommended",
+            "ElectrodeManufacturer": "recommended",
+            "ElectrodeManufacturersModelName": "recommended",
+            "ECOGChannelCount": "recommended",
+            "SEEGChannelCount": "recommended",
+            "EEGChannelCount": "recommended",
+            "EOGChannelCount": "recommended",
+            "ECGChannelCount": "recommended",
+            "EMGChannelCount": "recommended",
+            "MiscChannelCount": "recommended",
+            "TriggerChannelCount": "recommended",
+            "RecordingDuration": "recommended",
+            "RecordingType": "recommended",
+            "EpochLength": "recommended",
+            "iEEGGround": "recommended",
+            "iEEGPlacementScheme": "recommended",
+            "iEEGElectrodeGroups": "recommended",
+            "SubjectArtefactDescription": "recommended"
+          }
+        },
+        "iEEGOptional": {
+          "selectors": [
+            "modality == \"ieeg\"",
+            "datatype == \"ieeg\"",
+            "suffix == \"ieeg\""
+          ],
+          "fields": {
+            "ElectricalStimulation": "optional",
+            "ElectricalStimulationParameters": "optional"
+          }
+        },
+        "iEEGCoordsystemGeneral": {
+          "selectors": [
+            "modality == \"ieeg\"",
+            "datatype == \"ieeg\"",
+            "suffix == \"coordsystem\""
+          ],
+          "fields": {
+            "IntendedFor__ds_relative": {
+              "level": "optional",
+              "description_addendum": "If only a surface reconstruction is available, this should point to\nthe surface reconstruction file.\nNote that this file should have the same coordinate system\nspecified in `iEEGCoordinateSystem`.\nFor example, **T1**: `'bids::sub-<label>/ses-<label>/anat/sub-01_T1w.nii.gz'`\n**Surface**: `'bids::derivatives/surfaces/sub-<label>/ses-<label>/anat/\nsub-01_hemi-R_desc-T1w_pial.surf.gii'`\n**Operative photo**: `'bids::sub-<label>/ses-<label>/ieeg/\nsub-0001_ses-01_acq-photo1_photo.jpg'`\n**Talairach**: `'bids::derivatives/surfaces/sub-Talairach/ses-01/anat/\nsub-Talairach_hemi-R_pial.surf.gii'`\n"
+            }
+          }
+        },
+        "iEEGCoordsystemPositions": {
+          "selectors": [
+            "modality == \"ieeg\"",
+            "datatype == \"ieeg\"",
+            "suffix == \"coordsystem\""
+          ],
+          "fields": {
+            "iEEGCoordinateSystem": "required",
+            "iEEGCoordinateUnits": "required",
+            "iEEGCoordinateSystemDescription": {
+              "level": "recommended",
+              "level_addendum": "required if `iEEGCoordinateSystem` is `\"Other\"`"
+            },
+            "iEEGCoordinateProcessingDescription": "recommended",
+            "iEEGCoordinateProcessingReference": "recommended"
+          }
+        },
+        "iEEGCoordsystemOther": {
+          "selectors": [
+            "modality == \"ieeg\"",
+            "datatype == \"ieeg\"",
+            "suffix == \"coordsystem\"",
+            "\"iEEGCoordinateSystem\" in sidecar",
+            "sidecar.iEEGCoordinateSystem == \"Other\""
+          ],
+          "fields": {
+            "iEEGCoordinateSystemDescription": "required"
+          }
+        }
+      },
+      "meg": {
+        "MEGGeneric": {
+          "selectors": [
+            "modality == \"meg\"",
+            "datatype == \"meg\"",
+            "suffix == \"meg\""
+          ],
+          "fields": {
+            "TaskName": {
+              "level": "required",
+              "description_addendum": "A recommended convention is to name resting state task using labels\nbeginning with `rest`.\n"
+            }
+          }
+        },
+        "MEGRecommended": {
+          "selectors": [
+            "modality == \"meg\"",
+            "datatype == \"meg\"",
+            "suffix == \"meg\""
+          ],
+          "fields": {
+            "InstitutionName": "recommended",
+            "InstitutionAddress": "recommended",
+            "InstitutionalDepartmentName": "recommended",
+            "Manufacturer": {
+              "level": "recommended",
+              "description_addendum": "For MEG scanners, this must be one of:\n`\"CTF\"`, `\"Elekta/Neuromag\"`, `\"BTi/4D\"`, `\"KIT/Yokogawa\"`,\n`\"ITAB\"`, `\"KRISS\"`, `\"Other\"`.\nSee the [MEG Systems Appendix](SPEC_ROOT/appendices/meg-systems.md) for\npreferred names.\n"
+            },
+            "ManufacturersModelName": {
+              "level": "recommended",
+              "description_addendum": "See the [MEG Systems Appendix](SPEC_ROOT/appendices/meg-systems.md) for\npreferred names.\n"
+            },
+            "SoftwareVersions": "recommended",
+            "TaskDescription": "recommended",
+            "Instructions": {
+              "level": "recommended",
+              "description_addendum": "This is especially important in context of resting state recordings and\ndistinguishing between eyes open and eyes closed paradigms.\n"
+            },
+            "CogAtlasID": "recommended",
+            "CogPOID": "recommended",
+            "DeviceSerialNumber": "recommended"
+          }
+        },
+        "MEGRequired": {
+          "selectors": [
+            "modality == \"meg\"",
+            "datatype == \"meg\"",
+            "suffix == \"meg\""
+          ],
+          "fields": {
+            "SamplingFrequency": {
+              "level": "required",
+              "description_addendum": "The sampling frequency of data channels that deviate from the main sampling\nfrequency SHOULD be specified in the `channels.tsv` file.\n"
+            },
+            "PowerLineFrequency": "required",
+            "DewarPosition": "required",
+            "SoftwareFilters": "required",
+            "DigitizedLandmarks": "required",
+            "DigitizedHeadPoints": "required"
+          }
+        },
+        "MEGMoreRecommended": {
+          "selectors": [
+            "modality == \"meg\"",
+            "datatype == \"meg\"",
+            "suffix == \"meg\""
+          ],
+          "fields": {
+            "MEGChannelCount": "recommended",
+            "MEGREFChannelCount": "recommended",
+            "EEGChannelCount": "recommended",
+            "ECOGChannelCount": "recommended",
+            "SEEGChannelCount": "recommended",
+            "EOGChannelCount": "recommended",
+            "ECGChannelCount": "recommended",
+            "EMGChannelCount": "recommended",
+            "MiscChannelCount": "recommended",
+            "TriggerChannelCount": "recommended",
+            "RecordingDuration": "recommended",
+            "RecordingType": "recommended",
+            "EpochLength": "recommended",
+            "ContinuousHeadLocalization": "recommended",
+            "HeadCoilFrequency": "recommended",
+            "MaxMovement": "recommended",
+            "SubjectArtefactDescription": "recommended",
+            "AssociatedEmptyRoom": "recommended",
+            "HardwareFilters": "recommended"
+          }
+        },
+        "MEGwithEEG": {
+          "selectors": [
+            "modality == \"meg\"",
+            "datatype == \"meg\"",
+            "suffix == \"meg\"",
+            "intersects(dataset.modalities, [\"eeg\"])"
+          ],
+          "fields": {
+            "EEGPlacementScheme": "optional",
+            "CapManufacturer": "optional",
+            "CapManufacturersModelName": "optional",
+            "EEGReference": "optional"
+          }
+        },
+        "MEGCoordsystemWithEEG": {
+          "selectors": [
+            "modality == \"meg\"",
+            "datatype == \"meg\"",
+            "suffix == \"coordsystem\""
+          ],
+          "fields": {
+            "MEGCoordinateSystem": "required",
+            "MEGCoordinateUnits": "required",
+            "MEGCoordinateSystemDescription": {
+              "level": "optional",
+              "level_addendum": "required if `MEGCoordinateSystem` is `Other`"
+            },
+            "EEGCoordinateSystem": {
+              "level": "optional",
+              "description_addendum": "See [Recording EEG simultaneously with MEG]\n(/04-modality-specific-files/02-magnetoencephalography.html#recording-eeg-simultaneously-with-meg).\nPreferably the same as the `MEGCoordinateSystem`.\n"
+            },
+            "EEGCoordinateUnits": "optional",
+            "EEGCoordinateSystemDescription": {
+              "level": "optional",
+              "level_addendum": "required if `EEGCoordinateSystem` is `Other`",
+              "description_addendum": "See [Recording EEG simultaneously with MEG]\n(/04-modality-specific-files/02-magnetoencephalography.html#recording-eeg-simultaneously-with-meg).\n"
+            }
+          }
+        },
+        "MEGCoordsystemWithEEGMEGCoordinateSystem": {
+          "selectors": [
+            "modality == \"meg\"",
+            "datatype == \"meg\"",
+            "suffix == \"coordsystem\"",
+            "\"MEGCoordinateSystem\" in sidecar",
+            "sidecar.MEGCoordinateSystem == \"Other\""
+          ],
+          "fields": {
+            "MEGCoordinateSystemDescription": "required"
+          }
+        },
+        "MEGCoordsystemWithEEGEEGCoordinateSystem": {
+          "selectors": [
+            "modality == \"meg\"",
+            "datatype == \"meg\"",
+            "suffix == \"coordsystem\"",
+            "\"EEGCoordinateSystem\" in sidecar",
+            "sidecar.EEGCoordinateSystem == \"Other\""
+          ],
+          "fields": {
+            "EEGCoordinateSystemDescription": "required"
+          }
+        },
+        "MEGCoordsystemHeadLocalizationCoils": {
+          "selectors": [
+            "modality == \"meg\"",
+            "datatype == \"meg\"",
+            "suffix == \"coordsystem\""
+          ],
+          "fields": {
+            "HeadCoilCoordinates": "optional",
+            "HeadCoilCoordinateSystem": "optional",
+            "HeadCoilCoordinateUnits": "optional",
+            "HeadCoilCoordinateSystemDescription": {
+              "level": "optional",
+              "level_addendum": "required if `HeadCoilCoordinateSystem` is `Other`"
+            }
+          }
+        },
+        "MEGCoordsystemHeadLocalizationCoilsHeadCoilCoordinateSystem": {
+          "selectors": [
+            "modality == \"meg\"",
+            "datatype == \"meg\"",
+            "suffix == \"coordsystem\"",
+            "\"HeadCoilCoordinateSystem\" in sidecar",
+            "sidecar.HeadCoilCoordinateSystem == \"Other\""
+          ],
+          "fields": {
+            "HeadCoilCoordinateSystemDescription": "required"
+          }
+        },
+        "MEGCoordsystemDigitizedHeadPoints": {
+          "selectors": [
+            "modality == \"meg\"",
+            "datatype == \"meg\"",
+            "suffix == \"coordsystem\""
+          ],
+          "fields": {
+            "DigitizedHeadPoints": "optional",
+            "DigitizedHeadPointsCoordinateSystem": "optional",
+            "DigitizedHeadPointsCoordinateUnits": "optional",
+            "DigitizedHeadPointsCoordinateSystemDescription": {
+              "level": "optional",
+              "level_addendum": "required if `DigitizedHeadPointsCoordinateSystem` is `Other`"
+            }
+          }
+        },
+        "MEGCoordsystemDigitizedHeadPointsDigitizedHeadPointsCoordinateSystem": {
+          "selectors": [
+            "modality == \"meg\"",
+            "datatype == \"meg\"",
+            "suffix == \"coordsystem\"",
+            "\"DigitizedHeadPointsCoordinateSystem\" in sidecar",
+            "sidecar.DigitizedHeadPointsCoordinateSystem == \"Other\""
+          ],
+          "fields": {
+            "DigitizedHeadPointsCoordinateSystemDescription": "required"
+          }
+        },
+        "MEGCoordsystemAnatomicalMRI": {
+          "selectors": [
+            "modality == \"meg\"",
+            "datatype == \"meg\"",
+            "suffix == \"coordsystem\"",
+            "intersects(dataset.datatypes, [\"anat\"])"
+          ],
+          "fields": {
+            "IntendedFor": {
+              "level": "optional",
+              "description_addendum": "This is used to identify the structural MRI(s),\npossibly of different types if a list is specified,\nto be used with the MEG recording.\n"
+            }
+          }
+        },
+        "MEGCoordsystemAnatomicalLandmarks": {
+          "selectors": [
+            "modality == \"meg\"",
+            "datatype == \"meg\"",
+            "suffix == \"coordsystem\""
+          ],
+          "fields": {
+            "AnatomicalLandmarkCoordinates": "optional",
+            "AnatomicalLandmarkCoordinateSystem": {
+              "level": "optional",
+              "description_addendum": "Preferably the same as the `MEGCoordinateSystem`.\n"
+            },
+            "AnatomicalLandmarkCoordinateUnits": "optional",
+            "AnatomicalLandmarkCoordinateSystemDescription": {
+              "level": "optional",
+              "level_addendum": "required if `AnatomicalLandmarkCoordinateSystem` is `Other`"
+            }
+          }
+        },
+        "MEGCoordsystemAnatomicalLandmarksAnatomicalLandmarkCoordinateSystem": {
+          "selectors": [
+            "modality == \"meg\"",
+            "datatype == \"meg\"",
+            "suffix == \"coordsystem\"",
+            "\"AnatomicalLandmarkCoordinateSystem\" in sidecar",
+            "sidecar.AnatomicalLandmarkCoordinateSystem == \"Other\""
+          ],
+          "fields": {
+            "AnatomicalLandmarkCoordinateSystemDescription": "required"
+          }
+        },
+        "MEGCoordsystemFiducialsInformation": {
+          "selectors": [
+            "modality == \"meg\"",
+            "datatype == \"meg\"",
+            "suffix == \"coordsystem\""
+          ],
+          "fields": {
+            "FiducialsDescription": "optional"
+          }
+        }
+      },
+      "micr": {
+        "MicroscopyDeviceHardware": {
+          "selectors": [
+            "modality == \"micr\"",
+            "datatype == \"micr\""
+          ],
+          "fields": {
+            "Manufacturer": "recommended",
+            "ManufacturersModelName": "recommended",
+            "DeviceSerialNumber": "recommended",
+            "StationName": "recommended",
+            "SoftwareVersions": "recommended",
+            "InstitutionName": "recommended",
+            "InstitutionAddress": "recommended",
+            "InstitutionalDepartmentName": "recommended"
+          }
+        },
+        "MicroscopyImageAcquisition": {
+          "selectors": [
+            "modality == \"micr\"",
+            "datatype == \"micr\""
+          ],
+          "fields": {
+            "PixelSize": "required",
+            "PixelSizeUnits": "required",
+            "Immersion": "optional",
+            "NumericalAperture": "optional",
+            "Magnification": "optional",
+            "ImageAcquisitionProtocol": "optional",
+            "OtherAcquisitionParameters": "optional"
+          }
+        },
+        "MicroscopySample": {
+          "selectors": [
+            "modality == \"micr\"",
+            "datatype == \"micr\""
+          ],
+          "fields": {
+            "BodyPart": {
+              "level": "recommended",
+              "description_addendum": "From [DICOM Body Part\nExamined](http://dicom.nema.org/medical/dicom/current/output/chtml/part16/chapter_L.html#chapter_L)\n(for example `\"BRAIN\"`).\n"
+            },
+            "BodyPartDetails": "recommended",
+            "BodyPartDetailsOntology": "optional",
+            "SampleEnvironment": "recommended",
+            "SampleEmbedding": "optional",
+            "SampleFixation": "optional",
+            "SampleStaining": "recommended",
+            "SamplePrimaryAntibody": "recommended",
+            "SampleSecondaryAntibody": "recommended",
+            "SliceThickness": "optional",
+            "TissueDeformationScaling": "optional",
+            "SampleExtractionProtocol": "optional",
+            "SampleExtractionInstitution": "optional"
+          }
+        },
+        "MicroscopyChunkTransformations": {
+          "selectors": [
+            "modality == \"micr\"",
+            "datatype == \"micr\"",
+            "\"chunk\" in entities"
+          ],
+          "fields": {
+            "ChunkTransformationMatrix": {
+              "level": "recommended",
+              "level_addendum": "if `chunk-<index>` is used in filenames"
+            }
+          }
+        },
+        "MicroscopyChunkTransformationsMatrixAxis": {
+          "selectors": [
+            "modality == \"micr\"",
+            "datatype == \"micr\"",
+            "\"chunk\" in entities",
+            "\"ChunkTransformationMatrix\" in sidecar"
+          ],
+          "fields": {
+            "ChunkTransformationMatrixAxis": {
+              "level": "required",
+              "level_addendum": "if `ChunkTransformationMatrix` is present"
+            }
+          }
+        },
+        "Photo": {
+          "selectors": [
+            "modality == \"micr\"",
+            "suffix == \"photo\""
+          ],
+          "fields": {
+            "PhotoDescription": "optional",
+            "IntendedFor": {
+              "level": "optional",
+              "description_addendum": "This field is OPTIONAL, in case the photos do not correspond\nto any particular images, it does not have to be filled.\n"
+            }
+          }
+        }
+      },
+      "mri": {
+        "MRIScannerHardware": {
+          "selectors": [
+            "modality == \"mri\""
+          ],
+          "fields": {
+            "Manufacturer": {
+              "level": "recommended",
+              "description_addendum": "Corresponds to DICOM Tag 0008, 0070 `Manufacturer`."
+            },
+            "ManufacturersModelName": {
+              "level": "recommended",
+              "description_addendum": "Corresponds to DICOM Tag 0008, 1090 `Manufacturers Model Name`."
+            },
+            "DeviceSerialNumber": {
+              "level": "recommended",
+              "description_addendum": "Corresponds to DICOM Tag 0018, 1000 `DeviceSerialNumber`."
+            },
+            "StationName": {
+              "level": "recommended",
+              "description_addendum": "Corresponds to DICOM Tag 0008, 1010 `Station Name`."
+            },
+            "SoftwareVersions": {
+              "level": "recommended",
+              "description_addendum": "Corresponds to DICOM Tag 0018, 1020 `Software Versions`."
+            },
+            "HardcopyDeviceSoftwareVersion": "DEPRECATED",
+            "MagneticFieldStrength": {
+              "level": "recommended, but required for Arterial Spin Labeling"
+            },
+            "ReceiveCoilName": "recommended",
+            "ReceiveCoilActiveElements": "recommended",
+            "GradientSetType": "recommended",
+            "MRTransmitCoilSequence": "recommended",
+            "MatrixCoilMode": "recommended",
+            "CoilCombinationMethod": "recommended"
+          }
+        },
+        "MRIScannerHardwareASL": {
+          "selectors": [
+            "datatype == \"perf\"",
+            "suffix == \"asl\"",
+            "intersects([suffix], [\"asl\", \"m0scan\"])"
+          ],
+          "fields": {
+            "MagneticFieldStrength": "required"
+          }
+        },
+        "MRISequenceSpecifics": {
+          "selectors": [
+            "modality == \"mri\""
+          ],
+          "fields": {
+            "PulseSequenceType": "recommended",
+            "ScanningSequence": "recommended",
+            "SequenceVariant": "recommended",
+            "ScanOptions": "recommended",
+            "SequenceName": "recommended",
+            "PulseSequenceDetails": "recommended",
+            "NonlinearGradientCorrection": "recommended, but required if [PET](./09-positron-emission-tomography.md) data are present\n",
+            "MRAcquisitionType": "recommended, but required for Arterial Spin Labeling",
+            "MTState": "recommended",
+            "MTOffsetFrequency": "optional",
+            "MTPulseBandwidth": "optional",
+            "MTNumberOfPulses": "optional",
+            "MTPulseShape": "optional",
+            "MTPulseDuration": "optional",
+            "SpoilingState": "recommended",
+            "SpoilingType": "optional",
+            "SpoilingRFPhaseIncrement": "optional",
+            "SpoilingGradientMoment": "optional",
+            "SpoilingGradientDuration": "optional"
+          }
+        },
+        "PETMRISequenceSpecifics": {
+          "selectors": [
+            "modality == \"mri\"",
+            "intersects(dataset.modalities, [\"pet\"])"
+          ],
+          "fields": {
+            "NonlinearGradientCorrection": "required"
+          }
+        },
+        "ASLMRISequenceSpecifics": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"perf\""
+          ],
+          "fields": {
+            "MRAcquisitionType": "required"
+          }
+        },
+        "MTParameters": {
+          "selectors": [
+            "sidecar.MTState == true"
+          ],
+          "fields": {
+            "MTOffsetFrequency": "recommended",
+            "MTPulseBandwidth": "recommended",
+            "MTNumberOfPulses": "recommended",
+            "MTPulseShape": "recommended",
+            "MTPulseDuration": "recommended"
+          }
+        },
+        "SpoilingType": {
+          "selectors": [
+            "sidecar.SpoilingState == true"
+          ],
+          "fields": {
+            "SpoilingType": "recommended"
+          }
+        },
+        "SpoilingRF": {
+          "selectors": [
+            "intersects([sidecar.SpoilingType], [\"RF\", \"COMBINED\"])"
+          ],
+          "fields": {
+            "SpoilingRFPhaseIncrement": "recommended"
+          }
+        },
+        "SpoilingGradient": {
+          "selectors": [
+            "intersects([sidecar.SpoilingType], [\"GRADIENT\", \"COMBINED\"])"
+          ],
+          "fields": {
+            "SpoilingGradientMoment": "recommended",
+            "SpoilingGradientDuration": "recommended"
+          }
+        },
+        "MRISpatialEncoding": {
+          "selectors": [
+            "modality == \"mri\""
+          ],
+          "fields": {
+            "NumberShots": "recommended",
+            "ParallelReductionFactorInPlane": "recommended",
+            "ParallelAcquisitionTechnique": "recommended",
+            "PartialFourier": "recommended",
+            "PartialFourierDirection": "recommended",
+            "EffectiveEchoSpacing": {
+              "level": "recommended",
+              "level_addendum": "required if corresponding fieldmap data present",
+              "description_addendum": "<sup>2</sup>"
+            },
+            "MixingTime": "recommended"
+          }
+        },
+        "PhaseEncodingDirectionRec": {
+          "selectors": [
+            "modality == \"mri\"",
+            "suffix != \"epi\""
+          ],
+          "fields": {
+            "PhaseEncodingDirection": {
+              "level": "recommended",
+              "level_addendum": "required if corresponding fieldmap data is present\nor when using multiple runs with different phase encoding directions\n(which can be later used for field inhomogeneity correction).\n"
+            },
+            "TotalReadoutTime": {
+              "level": "recommended",
+              "level_addendum": "required if corresponding 'field/distortion' maps\nacquired with opposing phase encoding directions are present\n(see [Case 4: Multiple phase encoded\ndirections](#case-4-multiple-phase-encoded-directions-pepolar))\n"
+            }
+          }
+        },
+        "PhaseEncodingDirectionReq": {
+          "selectors": [
+            "modality == \"mri\"",
+            "suffix == \"epi\""
+          ],
+          "fields": {
+            "PhaseEncodingDirection": {
+              "level": "required",
+              "issue": {
+                "name": "PHASE_ENCODING_DIRECTION_MUST_DEFINE",
+                "issue": "You have to define 'PhaseEncodingDirection' for this file.\n"
+              }
+            },
+            "TotalReadoutTime": {
+              "level": "required",
+              "description_addendum": "<sup>3</sup>",
+              "issue": {
+                "name": "TOTAL_READOUT_TIME_MUST_DEFINE",
+                "message": "You have to define 'TotalReadoutTime' for this file.\n"
+              }
+            }
+          }
+        },
+        "MRITimingParameters": {
+          "selectors": [
+            "modality == \"mri\""
+          ],
+          "fields": {
+            "EchoTime": {
+              "level": "recommended",
+              "level_addendum": "required if corresponding fieldmap data is present,\nor the data comes from a multi-echo sequence or Arterial Spin Labeling.\n",
+              "issue": {
+                "name": "ECHO_TIME_NOT_DEFINED",
+                "message": "You must define 'EchoTime' for this file. 'EchoTime' is the echo time (TE)\nfor the acquisition, specified in seconds. Corresponds to DICOM Tag\n0018, 0081 Echo Time (please note that the DICOM term is in milliseconds\nnot seconds). The data type number may apply to files from any MRI modality\nconcerned with a single value for this field, or to the files in a file\ncollection where the value of this field is iterated using the echo entity.\nThe data type array provides a value for each volume in a 4D dataset and\nshould only be used when the volume timing is critical for interpretation\nof the data, such as in ASL or variable echo time fMRI sequences.\n"
+              }
+            },
+            "InversionTime": "recommended",
+            "SliceTiming": {
+              "level": "recommended",
+              "level_addendum": "required for sparse sequences that do not have the `DelayTime` field set,\nand Arterial Spin Labeling with `MRAcquisitionType` set on `2D`.\n"
+            },
+            "SliceEncodingDirection": "recommended",
+            "DwellTime": "recommended"
+          }
+        },
+        "SliceTimingASL": {
+          "selectors": [
+            "modality == \"mri\"",
+            "datatype == \"perf\"",
+            "intersects([suffix], [\"asl\", \"m0scan\"])",
+            "sidecar.MRAcquisitionType == \"2D\""
+          ],
+          "fields": {
+            "EchoTime": "required",
+            "SliceTiming": {
+              "level": "required",
+              "issue": {
+                "code": "SLICE_TIMING_NOT_DEFINED_2D_ASL",
+                "message": "You should define `SliceTiming` for this file, because `SequenceType` is sets\nto a 2D sequence. `SliceTiming` is the time at which each slice was\nacquired within each volume (frame) of the acquisition. Slice timing\nis not slice order -- rather, it is a list of times containing the\ntime (in seconds) of each slice acquisition in relation to the beginning\nof volume acquisition. The list goes through the slices along the slice\naxis in the slice encoding dimension (see below). Note that to ensure the\nproper interpretation of the `SliceTiming` field, it is important to check\nif the optional `SliceEncodingDirection` exists. In particular, if\n`SliceEncodingDirection` is negative, the entries in `SliceTiming` are\ndefined in reverse order with respect to the slice axis, such that the\nfinal entry in the `SliceTiming` list is the time of acquisition of slice 0.\nWithout this parameter slice time correction will not be possible.\n"
+              }
+            }
+          }
+        },
+        "MRIRFandContrast": {
+          "selectors": [
+            "modality == \"mri\""
+          ],
+          "fields": {
+            "NegativeContrast": "optional"
+          }
+        },
+        "MRIFlipAngleLookLockerFalse": {
+          "selectors": [
+            "modality == \"mri\"",
+            "sidecar.LookLocker != true"
+          ],
+          "fields": {
+            "FlipAngle": {
+              "level": "recommended",
+              "level_addendum": "required if LookLocker is set to `true`"
+            }
+          }
+        },
+        "MRIFlipAngleLookLockerTrue": {
+          "selectors": [
+            "modality == \"mri\"",
+            "sidecar.LookLocker == true"
+          ],
+          "fields": {
+            "FlipAngle": {
+              "level": "required",
+              "issue": {
+                "name": "LOOK_LOCKER_FLIP_ANGLE_MISSING",
+                "message": "You should define 'FlipAngle' for this file, in\ncase of a LookLocker acquisition. 'FlipAngle' is the\nflip angle (FA) for the acquisition, specified in degrees.\nCorresponds to: DICOM Tag 0018, 1314 `Flip Angle`. The data\ntype number may apply to files from any MRI modality concerned\nwith a single value for this field, or to the files in a file\ncollection where the value of this field is iterated using the\nflip entity. The data type array provides a value for each volume\nin a 4D dataset and should only be used when the volume timing is\ncritical for interpretation of the data, such as in ASL or\nvariable flip angle fMRI sequences.\n"
+              }
+            }
+          }
+        },
+        "MRISliceAcceleration": {
+          "selectors": [
+            "modality == \"mri\""
+          ],
+          "fields": {
+            "MultibandAccelerationFactor": "recommended"
+          }
+        },
+        "MRIAnatomicalLandmarks": {
+          "selectors": [
+            "modality == \"mri\""
+          ],
+          "fields": {
+            "AnatomicalLandmarkCoordinates__mri": "recommended"
+          }
+        },
+        "MRIEchoPlanarImagingAndB0Mapping": {
+          "selectors": [
+            "modality == \"mri\""
+          ],
+          "fields": {
+            "B0FieldIdentifier": "recommended",
+            "B0FieldSource": "recommended"
+          }
+        },
+        "MRIInstitutionInformation": {
+          "selectors": [
+            "modality == \"mri\""
+          ],
+          "fields": {
+            "InstitutionName": {
+              "level": "recommended",
+              "description_addendum": "Corresponds to DICOM Tag 0008, 0080 `InstitutionName`."
+            },
+            "InstitutionAddress": {
+              "level": "recommended",
+              "description_addendum": "Corresponds to DICOM Tag 0008, 0081 `InstitutionAddress`."
+            },
+            "InstitutionalDepartmentName": {
+              "level": "recommended",
+              "description_addendum": "Corresponds to DICOM Tag 0008, 1040 `Institutional Department Name`."
+            }
+          }
+        }
+      },
+      "nirs": {
+        "CoordinateSystem": {
+          "selectors": [
+            "datatype == \"nirs\"",
+            "suffix == \"coordsystem\""
+          ],
+          "fields": {
+            "NIRSCoordinateSystem": "required",
+            "NIRSCoordinateUnits": "required",
+            "NIRSCoordinateProcessingDescription": "recommended"
+          }
+        },
+        "Fiducials": {
+          "selectors": [
+            "datatype == \"nirs\"",
+            "suffix == \"coordsystem\""
+          ],
+          "fields": {
+            "FiducialsDescription": "optional",
+            "FiducialsCoordinates": "recommended",
+            "FiducialsCoordinateUnits": "recommended",
+            "FiducialsCoordinateSystem": "recommended"
+          }
+        },
+        "AnatomicalLandmark": {
+          "selectors": [
+            "datatype == \"nirs\"",
+            "suffix == \"coordsystem\""
+          ],
+          "fields": {
+            "AnatomicalLandmarkCoordinates": "recommended",
+            "AnatomicalLandmarkCoordinateSystem": "recommended",
+            "AnatomicalLandmarkCoordinateUnits": "recommended"
+          }
+        },
+        "CoordsystemGeneral": {
+          "selectors": [
+            "modality == \"nirs\"",
+            "datatype == \"nirs\"",
+            "suffix == \"coordsystem\""
+          ],
+          "fields": {
+            "IntendedFor": {
+              "level": "optional",
+              "description_addendum": "This identifies the MRI or CT scan associated with the optodes,\nlandmarks, and fiducials.\n"
+            }
+          }
+        },
+        "CoordinateSystemDescriptionRec": {
+          "selectors": [
+            "datatype == \"nirs\"",
+            "suffix == \"coordsystem\"",
+            "json.NIRSCoordinateSystem != \"other\""
+          ],
+          "fields": {
+            "NIRSCoordinateSystemDescription": {
+              "level": "recommended",
+              "level_addendum": "required if NIRSCoordinateSystem is \"other\""
+            }
+          }
+        },
+        "CoordinateSystemDescriptionReq": {
+          "selectors": [
+            "datatype == \"nirs\"",
+            "suffix == \"coordsystem\"",
+            "json.NIRSCoordinateSystem == \"other\""
+          ],
+          "fields": {
+            "NIRSCoordinateSystemDescription": "required"
+          }
+        },
+        "AnatomicalLandmarkCoordinateSystemDescriptionRec": {
+          "selectors": [
+            "datatype == \"nirs\"",
+            "suffix == \"coordsystem\"",
+            "json.AnatomicalLandmarkCoordinateSystem != \"other\""
+          ],
+          "fields": {
+            "AnatomicalLandmarkCoordinateSystemDescription": {
+              "level": "recommended",
+              "level_addendum": "required if NIRSCoordinateSystem is \"other\""
+            }
+          }
+        },
+        "AnatomicalLandmarkCoordinateSystemDescriptionReq": {
+          "selectors": [
+            "datatype == \"nirs\"",
+            "suffix == \"coordsystem\"",
+            "json.AnatomicalLandmarkCoordinateSystem == \"other\""
+          ],
+          "fields": {
+            "AnatomicalLandmarkCoordinateSystemDescription": "required"
+          }
+        },
+        "FiducialsCoordinateSystemDescriptionRec": {
+          "selectors": [
+            "datatype == \"nirs\"",
+            "suffix == \"coordsystem\"",
+            "json.FiducialsCoordinateSystem != \"other\""
+          ],
+          "fields": {
+            "FiducialsCoordinateSystemDescription": {
+              "level": "recommended",
+              "level_addendum": "required if FiducialsCoordinateSystem is \"other\""
+            }
+          }
+        },
+        "FiducialsCoordinateSystemDescriptionReq": {
+          "selectors": [
+            "datatype == \"nirs\"",
+            "suffix == \"coordsystem\"",
+            "json.FiducialsCoordinateSystem == \"other\""
+          ],
+          "fields": {
+            "FiducialsCoordinateSystemDescription": "required"
+          }
+        },
+        "NirsBase": {
+          "selectors": [
+            "datatype == \"nirs\"",
+            "suffix == \"nirs\""
+          ],
+          "fields": {
+            "TaskName": "required",
+            "InstitutionName": "recommended",
+            "InstitutionAddress": "recommended",
+            "Manufacturer": "recommended",
+            "ManufacturersModelName": "recommended",
+            "SoftwareVersions": "recommended",
+            "TaskDescription": "recommended",
+            "Instructions": "recommended",
+            "CogAtlasID": "recommended",
+            "CogPOID": "recommended",
+            "DeviceSerialNumber": "recommended",
+            "RecordingDuration": "recommended",
+            "HeadCircumference": "recommended",
+            "HardwareFilters": "recommended",
+            "SubjectArtefactDescription": "recommended"
+          }
+        },
+        "NirsRequired": {
+          "selectors": [
+            "datatype == \"nirs\"",
+            "suffix == \"nirs\""
+          ],
+          "fields": {
+            "SamplingFrequency__nirs": {
+              "level": "required",
+              "description_addendum": "Sampling frequency (in Hz) of all the data in the recording, regardless of their type (for example, `12`). If\nindividual channels have different sampling rates, then the field here MUST be specified as `n/a` and the\nvalues MUST be specified in the `sampling_frequency` column in channels.tsv.\")\n"
+            },
+            "NIRSChannelCount": "required",
+            "NIRSSourceOptodeCount": "required",
+            "NIRSDetectorOptodeCount": "required",
+            "ACCELChannelCount": {
+              "level": "optional",
+              "level_addendum": "required if any channel type is ACC"
+            },
+            "GYROChannelCount": {
+              "level": "optional",
+              "level_addendum": "required if any channel type is GYRO"
+            },
+            "MAGNChannelCount": {
+              "level": "optional",
+              "level_addendum": "required if any channel type is MAGN"
+            }
+          }
+        },
+        "NirsRecommend": {
+          "selectors": [
+            "modality == \"nirs\"",
+            "suffix == \"nirs\""
+          ],
+          "fields": {
+            "CapManufacturer": {
+              "level": "recommended",
+              "description_addendum": "If no cap was used, such as with optodes\nthat are directly taped to the scalp, then the string `none` MUST be used and the `NIRSPlacementScheme` field\nMAY be used to specify the optode placement.\n"
+            },
+            "CapManufacturersModelName": {
+              "level": "recommended",
+              "description_addendum": "If there is no official model number then a description may be provided (for example, `Headband with print\n(S-M)`). If a cap from a manufacturer was modified, then the field MUST be set to `custom`. If no cap\nwas used, then the `CapManufacturer` field MUST be `none` and this field MUST be `n/a`.\")\n"
+            },
+            "SourceType": "recommended",
+            "DetectorType": "recommended",
+            "ShortChannelCount": "recommended",
+            "NIRSPlacementScheme": "recommended"
+          }
+        }
+      },
+      "pet": {
+        "PETScannerHardware": {
+          "selectors": [
+            "modality == \"pet\"",
+            "suffix == \"pet\""
+          ],
+          "fields": {
+            "Manufacturer": {
+              "level": "required",
+              "description_addendum": "Corresponds to DICOM Tag 0008, 0070 `Manufacturer`."
+            },
+            "ManufacturersModelName": {
+              "level": "required",
+              "description_addendum": "Corresponds to DICOM Tag 0008, 1090 `Manufacturers Model Name`."
+            },
+            "Units": {
+              "level": "required",
+              "description_addendum": "SI unit for radioactivity (Becquerel) should be used (for example, \"Bq/mL\").\nCorresponds to DICOM Tag 0054, 1001 `Units`.\n"
+            },
+            "InstitutionName": {
+              "level": "recommended",
+              "description_addendum": "Corresponds to DICOM Tag 0008, 0080 `InstitutionName`."
+            },
+            "InstitutionAddress": {
+              "level": "recommended",
+              "description_addendum": "Corresponds to DICOM Tag 0008, 0081 `InstitutionAddress`."
+            },
+            "InstitutionalDepartmentName": {
+              "level": "recommended",
+              "description_addendum": "Corresponds to DICOM Tag 0008, 1040 `Institutional Department Name`."
+            },
+            "BodyPart": {
+              "level": "recommended",
+              "description_addendum": "Corresponds to DICOM Tag 0018, 0015 `Body Part Examined`."
+            }
+          }
+        },
+        "PETRadioChemistry": {
+          "selectors": [
+            "modality == \"pet\"",
+            "suffix == \"pet\""
+          ],
+          "fields": {
+            "TracerName": {
+              "level": "required",
+              "description_addendum": "Corresponds to DICOM Tags (0008,0105) `Mapping Resource` and\n(0008,0122) `Mapping Resource Name`.\n"
+            },
+            "TracerRadionuclide": {
+              "level": "required",
+              "description_addendum": "Corresponds to DICOM Tags (0008,0104) `CodeValue` and (0008,0104) `CodeMeaning`.\n"
+            },
+            "InjectedRadioactivity": "required",
+            "InjectedRadioactivityUnits": "required",
+            "InjectedMass": "required",
+            "InjectedMassUnits": "required",
+            "SpecificRadioactivity": "required",
+            "SpecificRadioactivityUnits": "required",
+            "ModeOfAdministration": "required",
+            "TracerRadLex": "recommended",
+            "TracerSNOMED": "recommended",
+            "TracerMolecularWeight": "recommended",
+            "TracerMolecularWeightUnits": "recommended",
+            "InjectedMassPerWeight": "recommended",
+            "InjectedMassPerWeightUnits": "recommended",
+            "SpecificRadioactivityMeasTime": "recommended",
+            "MolarActivity": "recommended",
+            "MolarActivityUnits": "recommended",
+            "MolarActivityMeasTime": "recommended",
+            "InfusionRadioactivity": {
+              "level": "recommended",
+              "level_addendum": "required if ModeOfAdministration is `'bolus-infusion'`"
+            },
+            "InfusionStart": {
+              "level": "recommended",
+              "level_addendum": "required if ModeOfAdministration is `'bolus-infusion'`"
+            },
+            "InfusionSpeed": {
+              "level": "recommended",
+              "level_addendum": "required if ModeOfAdministration is `'bolus-infusion'`"
+            },
+            "InfusionSpeedUnits": {
+              "level": "recommended",
+              "level_addendum": "required if ModeOfAdministration is `'bolus-infusion'`"
+            },
+            "InjectedVolume": {
+              "level": "recommended",
+              "level_addendum": "required if ModeOfAdministration is `'bolus-infusion'`"
+            },
+            "Purity": "recommended"
+          }
+        },
+        "EntitiesBolusMetadata": {
+          "selectors": [
+            "modality == \"pet\"",
+            "suffix == \"pet\"",
+            "sidecar.ModeOfAdministration == 'bolus-infusion'"
+          ],
+          "fields": {
+            "InfusionRadioactivity": "required",
+            "InfusionStart": "required",
+            "InfusionSpeed": "required",
+            "InfusionSpeedUnits": "required",
+            "InjectedVolume": "required"
+          }
+        },
+        "PETPharmaceuticals": {
+          "selectors": [
+            "modality == \"pet\"",
+            "suffix == \"pet\""
+          ],
+          "fields": {
+            "PharmaceuticalName": {
+              "level": "recommended",
+              "description_addendum": "Corresponds to DICOM Tag (0008,0034) `Intervention Drug Name`."
+            },
+            "PharmaceuticalDoseAmount": {
+              "level": "recommended",
+              "description_addendum": "Corresponds to DICOM Tag (0008,0028) `Intervention Drug Dose`."
+            },
+            "PharmaceuticalDoseUnits": "recommended",
+            "PharmaceuticalDoseRegimen": "recommended",
+            "PharmaceuticalDoseTime": {
+              "level": "recommended",
+              "description_addendum": "Corresponds to a combination of DICOM Tags (0008,0027) `Intervention Drug Stop Time`\nand (0008,0035) `Intervention Drug Start Time`.\n"
+            },
+            "Anaesthesia": "optional"
+          }
+        },
+        "PETTime": {
+          "selectors": [
+            "modality == \"pet\"",
+            "suffix == \"pet\""
+          ],
+          "fields": {
+            "TimeZero": "required",
+            "ScanStart": "required",
+            "InjectionStart": {
+              "level": "required",
+              "description_addendum": "Corresponds to DICOM Tag (0018,1072) `Radiopharmaceutical Start Time`."
+            },
+            "FrameTimesStart": "required",
+            "FrameDuration": "required",
+            "InjectionEnd": {
+              "level": "recommended",
+              "description_addendum": "Corresponds to DICOM Tag (0018,1073) `Radiopharmaceutical Stop Time`\nconverted to seconds relative to TimeZero.\n"
+            },
+            "ScanDate": {
+              "level": "deprecated",
+              "description_addendum": "Corresponds to DICOM Tag (0008,0022) `Acquisition Date`."
+            }
+          }
+        },
+        "PETReconstruction": {
+          "selectors": [
+            "modality == \"pet\"",
+            "suffix == \"pet\""
+          ],
+          "fields": {
+            "AcquisitionMode": "required",
+            "ImageDecayCorrected": "required",
+            "ImageDecayCorrectionTime": "required",
+            "ReconMethodName": {
+              "level": "required",
+              "description_addendum": "This partly matches the DICOM Tag (0054,1103) `Reconstruction Method`."
+            },
+            "ReconMethodParameterLabels": {
+              "level": "required",
+              "description_addendum": "This partly matches the DICOM Tag (0054,1103) `Reconstruction Method`."
+            },
+            "ReconMethodParameterUnits": {
+              "level": "recommended",
+              "level_addendum": "required if `ReconMethodParameterLabels` does not contain `\"none\"`",
+              "description_addendum": "This partly matches the DICOM Tag (0054,1103) `Reconstruction Method`."
+            },
+            "ReconMethodParameterValues": {
+              "level": "recommended",
+              "level_addendum": "required if `ReconMethodParameterLabels` does not contain `\"none\"`",
+              "description_addendum": "This partly matches the DICOM Tag (0054,1103) `Reconstruction Method`."
+            },
+            "ReconFilterType": {
+              "level": "required",
+              "description_addendum": "This partly matches the DICOM Tag (0018,1210) `Convolution Kernel`."
+            },
+            "ReconFilterSize": {
+              "level": "recommended",
+              "level_addendum": "required if `ReconFilterType` is not `\"none\"`",
+              "description_addendum": "This partly matches the DICOM Tag (0018,1210) `Convolution Kernel`."
+            },
+            "AttenuationCorrection": {
+              "level": "required",
+              "description_addendum": "This corresponds to DICOM Tag (0054,1101) `Attenuation Correction Method`."
+            },
+            "ReconMethodImplementationVersion": "recommended",
+            "AttenuationCorrectionMethodReference": "recommended",
+            "ScaleFactor": "recommended",
+            "ScatterFraction": {
+              "level": "recommended",
+              "description_addendum": "Corresponds to DICOM Tag (0054,1323) `Scatter Fraction Factor`."
+            },
+            "DecayCorrectionFactor": {
+              "level": "recommended",
+              "description_addendum": "Corresponds to DICOM Tag (0054,1321) `Decay Factor`."
+            },
+            "DoseCalibrationFactor": {
+              "level": "recommended",
+              "description_addendum": "Corresponds to DICOM Tag (0054,1322) `Dose Calibration Factor`."
+            },
+            "PromptRate": "recommended",
+            "SinglesRate": "recommended",
+            "RandomRate": "recommended"
+          }
+        },
+        "EntitiesReconMethodMetadata": {
+          "selectors": [
+            "modality == \"pet\"",
+            "suffix == \"pet\"",
+            "!intersects(sidecar.ReconMethodParameterLabels, [\"none\"])"
+          ],
+          "fields": {
+            "ReconMethodParameterValues": "required",
+            "ReconMethodParameterUnits": "required"
+          }
+        },
+        "EntitiesReconFilterMetadata": {
+          "selectors": [
+            "modality == \"pet\"",
+            "suffix == \"pet\"",
+            "!intersects(sidecar.ReconFilterType, [\"none\"])"
+          ],
+          "fields": {
+            "ReconFilterSize": "required"
+          }
+        },
+        "BloodRecording": {
+          "selectors": [
+            "modality == \"pet\"",
+            "suffix == \"blood\""
+          ],
+          "fields": {
+            "PlasmaAvail": "required",
+            "MetaboliteAvail": "required",
+            "WholeBloodAvail": "required",
+            "DispersionCorrected": "required",
+            "WithdrawalRate": "recommended",
+            "TubingType": "recommended",
+            "TubingLength": "recommended",
+            "DispersionConstant": "recommended",
+            "Haematocrit": "recommended",
+            "BloodDensity": "recommended"
+          }
+        },
+        "BloodPlasmaFreeFraction": {
+          "selectors": [
+            "modality == \"pet\"",
+            "suffix == \"blood\"",
+            "sidecar.PlasmaAvail == true"
+          ],
+          "fields": {
+            "PlasmaFreeFraction": {
+              "level": "recommended",
+              "level_addendum": "if `PlasmaAvail` is `true`"
+            },
+            "PlasmaFreeFractionMethod": {
+              "level": "recommended",
+              "level_addendum": "if `PlasmaAvail` is `true`"
+            }
+          }
+        },
+        "BloodMetaboliteMethod": {
+          "selectors": [
+            "modality == \"pet\"",
+            "suffix == \"blood\"",
+            "sidecar.MetaboliteAvail == true"
+          ],
+          "fields": {
+            "MetaboliteMethod": {
+              "level": "required",
+              "level_addendum": "if `MetaboliteAvail` is `true`"
+            },
+            "MetaboliteRecoveryCorrectionApplied": {
+              "level": "required",
+              "level_addendum": "if `MetaboliteAvail` is `true`"
+            }
+          }
+        },
+        "PETTask": {
+          "selectors": [
+            "modality == \"pet\"",
+            "\"task\" in entities"
+          ],
+          "fields": {
+            "TaskName": {
+              "level": "recommended",
+              "description_addendum": "If used to denote resting scans, a RECOMMENDED convention is to use labels\nbeginning with `rest`.\n"
+            },
+            "Instructions": {
+              "level": "recommended",
+              "description_addendum": "This is especially important in context of resting state recordings\nand distinguishing between eyes open and eyes closed paradigms.\n"
+            },
+            "TaskDescription": "recommended",
+            "CogAtlasID": "recommended",
+            "CogPOID": "recommended"
+          }
+        }
+      }
+    },
+    "tabular_data": {
+      "derivatives": {
+        "common_derivatives": {
+          "SegmentationLookup": {
+            "selectors": [
+              "dataset.dataset_description.DatasetType == \"derivative\"",
+              "intersects([suffix], [\"dseg\", \"probseg\"])"
+            ],
+            "columns": {
+              "index": "required",
+              "name__segmentations": "required",
+              "abbreviation": "optional",
+              "color": "optional",
+              "mapping": "optional"
+            },
+            "index_columns": [
+              "index"
+            ]
+          }
+        }
+      },
+      "eeg": {
+        "EEGChannels": {
+          "selectors": [
+            "datatype == \"eeg\"",
+            "suffix == \"channels\"",
+            "extension == \".tsv\""
+          ],
+          "initial_columns": [
+            "name__channels",
+            "type__eeg_channels",
+            "units"
+          ],
+          "columns": {
+            "name__channels": "required",
+            "type__eeg_channels": "required",
+            "units": "required",
+            "description": "optional",
+            "sampling_frequency": "optional",
+            "reference__eeg": "optional",
+            "low_cutoff": "optional",
+            "high_cutoff": "optional",
+            "notch": "optional",
+            "status": "optional",
+            "status_description": "optional"
+          },
+          "index_columns": [
+            "name__channels"
+          ],
+          "additional_columns": "allowed_if_defined"
+        },
+        "EEGElectrodes": {
+          "selectors": [
+            "datatype == \"eeg\"",
+            "suffix == \"electrodes\"",
+            "extension == \".tsv\""
+          ],
+          "initial_columns": [
+            "name__electrodes",
+            "x",
+            "y",
+            "z"
+          ],
+          "columns": {
+            "name__electrodes": "required",
+            "x": "required",
+            "y": "required",
+            "z": "required",
+            "type__electrodes": "recommended",
+            "material": "recommended",
+            "impedance": "recommended"
+          },
+          "index_columns": [
+            "name__electrodes"
+          ],
+          "additional_columns": "allowed_if_defined"
+        }
+      },
+      "ieeg": {
+        "iEEGChannels": {
+          "selectors": [
+            "datatype == \"ieeg\"",
+            "suffix == \"channels\"",
+            "extension == \".tsv\""
+          ],
+          "initial_columns": [
+            "name__channels",
+            "type__ieeg_channels",
+            "units"
+          ],
+          "columns": {
+            "name__channels": {
+              "level": "required",
+              "description_addendum": "When a corresponding electrode is specified in `_electrodes.tsv`,\nthe name of that electrode MAY be specified here and the reference electrode\nname MAY be provided in the `reference` column.\n"
+            },
+            "type__ieeg_channels": "required",
+            "units": "required",
+            "low_cutoff": "required",
+            "high_cutoff": "required",
+            "reference__ieeg": "optional",
+            "group__channel": {
+              "level": "optional",
+              "description_addendum": "Note that any groups specified in `_electrodes.tsv` must match those present here.\n"
+            },
+            "sampling_frequency": "optional",
+            "description": "optional",
+            "notch": "optional",
+            "status": "optional",
+            "status_description": "optional"
+          },
+          "index_columns": [
+            "name__channels"
+          ],
+          "additional_columns": "allowed_if_defined"
+        },
+        "iEEGElectrodes": {
+          "selectors": [
+            "datatype == \"ieeg\"",
+            "suffix == \"electrodes\"",
+            "extension == \".tsv\""
+          ],
+          "initial_columns": [
+            "name__electrodes",
+            "x",
+            "y",
+            "z"
+          ],
+          "columns": {
+            "name__electrodes": "required",
+            "x": "required",
+            "y": "required",
+            "z": {
+              "level": "required",
+              "description_addendum": "If electrodes are in 2D space this should be a column of `n/a` values.\n"
+            },
+            "size": "required",
+            "material": "recommended",
+            "manufacturer": "recommended",
+            "group__channel": {
+              "level": "recommended",
+              "description_addendum": "Note that any group specified here should match a group specified in `_channels.tsv`.\n"
+            },
+            "hemisphere": "recommended",
+            "type__electrodes": "optional",
+            "impedance": "optional",
+            "dimension": "optional"
+          },
+          "index_columns": [
+            "name__electrodes"
+          ],
+          "additional_columns": "allowed_if_defined"
+        }
+      },
+      "meg": {
+        "MEGChannels": {
+          "selectors": [
+            "datatype == \"meg\"",
+            "suffix == \"channels\"",
+            "extension == \".tsv\""
+          ],
+          "initial_columns": [
+            "name__channels",
+            "type__meg_channels",
+            "units"
+          ],
+          "columns": {
+            "name__channels": "required",
+            "type__meg_channels": "required",
+            "units": "required",
+            "description": "optional",
+            "sampling_frequency": "optional",
+            "low_cutoff": "optional",
+            "high_cutoff": "optional",
+            "notch": "optional",
+            "software_filters": "optional",
+            "status": "optional",
+            "status_description": "optional"
+          },
+          "index_columns": [
+            "name__channels"
+          ],
+          "additional_columns": "allowed_if_defined"
+        }
+      },
+      "modality_agnostic": {
+        "Participants": {
+          "selectors": [
+            "path == \"participants.tsv\""
+          ],
+          "initial_columns": [
+            "participant_id"
+          ],
+          "columns": {
+            "participant_id": {
+              "level": "required",
+              "description_addendum": "There MUST be exactly one row for each participant.\n"
+            },
+            "species": "recommended",
+            "age": "recommended",
+            "sex": "recommended",
+            "handedness": "recommended",
+            "strain": "recommended",
+            "strain_rrid": "recommended"
+          },
+          "index_columns": [
+            "participant_id"
+          ],
+          "additional_columns": "allowed"
+        },
+        "Samples": {
+          "selectors": [
+            "path == \"samples.tsv\""
+          ],
+          "columns": {
+            "sample_id": "required",
+            "participant_id": "required",
+            "sample_type": "required",
+            "pathology": "recommended",
+            "derived_from": "recommended"
+          },
+          "index_columns": [
+            "sample_id",
+            "participant_id"
+          ],
+          "additional_columns": "allowed"
+        },
+        "Scans": {
+          "selectors": [
+            "suffix == \"scans\"",
+            "extension == \".tsv\""
+          ],
+          "initial_columns": [
+            "filename"
+          ],
+          "columns": {
+            "filename": {
+              "level": "required",
+              "description_addendum": "There MUST be exactly one row for each file.\n"
+            },
+            "acq_time__scans": "optional"
+          },
+          "index_columns": [
+            "filename"
+          ],
+          "additional_columns": "allowed"
+        },
+        "Sessions": {
+          "selectors": [
+            "suffix == \"sessions\"",
+            "extension == \".tsv\""
+          ],
+          "initial_columns": [
+            "session_id"
+          ],
+          "columns": {
+            "session_id": {
+              "level": "required",
+              "description_addendum": "There MUST be exactly one row for each session.\n"
+            },
+            "acq_time__sessions": "optional",
+            "pathology": "recommended"
+          },
+          "index_columns": [
+            "session_id"
+          ],
+          "additional_columns": "allowed"
+        }
+      },
+      "nirs": {
+        "nirsChannels": {
+          "selectors": [
+            "datatype == \"nirs\"",
+            "suffix == \"channels\"",
+            "extension == \".tsv\""
+          ],
+          "initial_columns": [
+            "name__channels",
+            "type__nirs_channels",
+            "source__channels",
+            "detector__channels",
+            "wavelength_nominal",
+            "units__nirs"
+          ],
+          "columns": {
+            "name__channels": "required",
+            "type__nirs_channels": "required",
+            "source__channels": "required",
+            "detector__channels": "required",
+            "wavelength_nominal": "required",
+            "units__nirs": "required",
+            "sampling_frequency": {
+              "level": "optional",
+              "level_addendum": "required if `SamplingFrequency` is `n/a` in `_nirs.json`"
+            },
+            "orientation_component": {
+              "level": "optional",
+              "level_addendum": "required if `type` is `ACCEL`, `GYRO` or `MAGN`"
+            },
+            "wavelength_actual": "optional",
+            "description": "optional",
+            "wavelength_emission_actual": "optional",
+            "short_channel": "optional",
+            "status": "optional",
+            "status_description": "optional"
+          },
+          "additional_columns": "allowed_if_defined"
+        },
+        "nirsOptodes": {
+          "selectors": [
+            "datatype == \"nirs\"",
+            "suffix == \"optodes\"",
+            "extension == \".tsv\""
+          ],
+          "initial_columns": [
+            "name__optodes",
+            "type__optodes",
+            "x__optodes",
+            "y__optodes",
+            "z__optodes"
+          ],
+          "columns": {
+            "name__optodes": "required",
+            "type__optodes": "required",
+            "x__optodes": "required",
+            "y__optodes": "required",
+            "z__optodes": "required",
+            "template_x": {
+              "level": "optional",
+              "level_addendum": "required if `x` is `n/a`"
+            },
+            "template_y": {
+              "level": "optional",
+              "level_addendum": "required if `y` is `n/a`"
+            },
+            "template_z": {
+              "level": "optional",
+              "level_addendum": "required if `z` is `n/a`"
+            },
+            "description__optode": "optional",
+            "detector_type": "optional",
+            "source__optodes": "optional"
+          },
+          "additional_columns": "allowed_if_defined"
+        }
+      },
+      "perf": {
+        "ASLContext": {
+          "selectors": [
+            "datatype == \"perf\"",
+            "suffix == \"aslcontext\""
+          ],
+          "columns": {
+            "volume_type": "required"
+          },
+          "additional_columns": "not_allowed"
+        }
+      },
+      "pet": {
+        "Blood": {
+          "selectors": [
+            "modality == \"pet\"",
+            "suffix == \"blood\"",
+            "extension == \".tsv\""
+          ],
+          "columns": {
+            "time": "required",
+            "plasma_radioactivity": {
+              "level": "optional",
+              "level_addendum": "required if `PlasmaAvail` is `true`"
+            },
+            "metabolite_parent_fraction": {
+              "level": "optional",
+              "level_addendum": "required if `MetaboliteAvail` is `true`"
+            },
+            "metabolite_polar_fraction": {
+              "level": "optional",
+              "level_addendum": "required if `MetaboliteAvail` is `true`"
+            },
+            "hplc_recovery_fractions": {
+              "level": "optional",
+              "level_addendum": "required if `MetaboliteRecoveryCorrectionApplied` is `true`"
+            },
+            "whole_blood_radioactivity": {
+              "level": "optional",
+              "level_addendum": "required if `WholeBloodAvail` is `true`"
+            }
+          }
+        },
+        "BloodPlasma": {
+          "selectors": [
+            "modality == \"pet\"",
+            "suffix == \"blood\"",
+            "extension == \".tsv\"",
+            "\"PlasmaAvail\" in sidecar"
+          ],
+          "columns": {
+            "plasma_radioactivity": "required"
+          }
+        },
+        "BloodMetabolite": {
+          "selectors": [
+            "modality == \"pet\"",
+            "suffix == \"blood\"",
+            "extension == \".tsv\"",
+            "\"MetaboliteAvail\" in sidecar"
+          ],
+          "columns": {
+            "metabolite_parent_fraction": "required",
+            "metabolite_polar_fraction": "recommended"
+          }
+        },
+        "BloodMetaboliteCorrection": {
+          "selectors": [
+            "modality == \"pet\"",
+            "suffix == \"blood\"",
+            "extension == \".tsv\"",
+            "\"MetaboliteRecoveryCorrectionApplied\" in sidecar",
+            "sidecar.MetaboliteRecoveryCorrectionApplied == true"
+          ],
+          "columns": {
+            "hplc_recovery_fractions": "required"
+          }
+        },
+        "BloodWholeBlood": {
+          "selectors": [
+            "modality == \"pet\"",
+            "suffix == \"blood\"",
+            "extension == \".tsv\"",
+            "\"WholeBloodAvail\" in sidecar",
+            "sidecar.WholeBloodAvail == true"
+          ],
+          "columns": {
+            "whole_blood_radioactivity": "required"
+          }
+        }
+      },
+      "physio": {
+        "PhysioColumns": {
+          "selectors": [
+            "suffix == \"physio\""
+          ],
+          "columns": {
+            "cardiac": "optional",
+            "respiratory": "optional",
+            "trigger": "optional"
+          },
+          "additional_columns": "allowed"
+        }
+      },
+      "task": {
+        "TaskEvents": {
+          "selectors": [
+            "\"task\" in entities",
+            "suffix == \"events\""
+          ],
+          "columns": {
+            "onset": "required",
+            "duration": "required",
+            "sample": "optional",
+            "trial_type": "optional",
+            "response_time": "optional",
+            "value": "optional",
+            "HED": "optional",
+            "stim_file": "optional"
+          },
+          "additional_columns": "allowed",
+          "initial_columns": [
+            "onset",
+            "duration"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/pypet2bids/poetry.lock
+++ b/pypet2bids/poetry.lock
@@ -574,13 +574,13 @@ tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
 
 [[package]]
 name = "pluggy"
-version = "1.2.0"
+version = "1.3.0"
 description = "plugin and hook calling mechanisms for python"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "pluggy-1.2.0-py3-none-any.whl", hash = "sha256:c2fd55a7d7a3863cba1a013e4e2414658b1d07b6bc57b3919e0c63c9abb99849"},
-    {file = "pluggy-1.2.0.tar.gz", hash = "sha256:d12f0c4b579b15f5e054301bb226ee85eeeba08ffec228092f8defbaa3a4c4b3"},
+    {file = "pluggy-1.3.0-py3-none-any.whl", hash = "sha256:d89c696a773f8bd377d18e5ecda92b7a3793cbe66c87060a6fb58c7b6e1061f7"},
+    {file = "pluggy-1.3.0.tar.gz", hash = "sha256:cf61ae8f126ac6f7c451172cf30e3e43d3ca77615509771b3a984a0730651e12"},
 ]
 
 [package.extras]
@@ -628,23 +628,23 @@ plugins = ["importlib-metadata"]
 
 [[package]]
 name = "pyinstaller"
-version = "5.13.0"
+version = "5.13.2"
 description = "PyInstaller bundles a Python application and all its dependencies into a single package."
 optional = false
 python-versions = "<3.13,>=3.7"
 files = [
-    {file = "pyinstaller-5.13.0-py3-none-macosx_10_13_universal2.whl", hash = "sha256:7fdd319828de679f9c5e381eff998ee9b4164bf4457e7fca56946701cf002c3f"},
-    {file = "pyinstaller-5.13.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:0df43697c4914285ecd333be968d2cd042ab9b2670124879ee87931d2344eaf5"},
-    {file = "pyinstaller-5.13.0-py3-none-manylinux2014_i686.whl", hash = "sha256:28d9742c37e9fb518444b12f8c8ab3cb4ba212d752693c34475c08009aa21ccf"},
-    {file = "pyinstaller-5.13.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e5fb17de6c325d3b2b4ceaeb55130ad7100a79096490e4c5b890224406fa42f4"},
-    {file = "pyinstaller-5.13.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:78975043edeb628e23a73fb3ef0a273cda50e765f1716f75212ea3e91b09dede"},
-    {file = "pyinstaller-5.13.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:cd7d5c06f2847195a23d72ede17c60857d6f495d6f0727dc6c9bc1235f2eb79c"},
-    {file = "pyinstaller-5.13.0-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:24009eba63cfdbcde6d2634e9c87f545eb67249ddf3b514e0cd3b2cdaa595828"},
-    {file = "pyinstaller-5.13.0-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:1fde4381155f21d6354dc450dcaa338cd8a40aaacf6bd22b987b0f3e1f96f3ee"},
-    {file = "pyinstaller-5.13.0-py3-none-win32.whl", hash = "sha256:2d03419904d1c25c8968b0ad21da0e0f33d8d65716e29481b5bd83f7f342b0c5"},
-    {file = "pyinstaller-5.13.0-py3-none-win_amd64.whl", hash = "sha256:9fc27c5a853b14a90d39c252707673c7a0efec921cd817169aff3af0fca8c127"},
-    {file = "pyinstaller-5.13.0-py3-none-win_arm64.whl", hash = "sha256:3a331951f9744bc2379ea5d65d36f3c828eaefe2785f15039592cdc08560b262"},
-    {file = "pyinstaller-5.13.0.tar.gz", hash = "sha256:5e446df41255e815017d96318e39f65a3eb807e74a796c7e7ff7f13b6366a2e9"},
+    {file = "pyinstaller-5.13.2-py3-none-macosx_10_13_universal2.whl", hash = "sha256:16cbd66b59a37f4ee59373a003608d15df180a0d9eb1a29ff3bfbfae64b23d0f"},
+    {file = "pyinstaller-5.13.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8f6dd0e797ae7efdd79226f78f35eb6a4981db16c13325e962a83395c0ec7420"},
+    {file = "pyinstaller-5.13.2-py3-none-manylinux2014_i686.whl", hash = "sha256:65133ed89467edb2862036b35d7c5ebd381670412e1e4361215e289c786dd4e6"},
+    {file = "pyinstaller-5.13.2-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:7d51734423685ab2a4324ab2981d9781b203dcae42839161a9ee98bfeaabdade"},
+    {file = "pyinstaller-5.13.2-py3-none-manylinux2014_s390x.whl", hash = "sha256:2c2fe9c52cb4577a3ac39626b84cf16cf30c2792f785502661286184f162ae0d"},
+    {file = "pyinstaller-5.13.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:c63ef6133eefe36c4b2f4daf4cfea3d6412ece2ca218f77aaf967e52a95ac9b8"},
+    {file = "pyinstaller-5.13.2-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:aadafb6f213549a5906829bb252e586e2cf72a7fbdb5731810695e6516f0ab30"},
+    {file = "pyinstaller-5.13.2-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:b2e1c7f5cceb5e9800927ddd51acf9cc78fbaa9e79e822c48b0ee52d9ce3c892"},
+    {file = "pyinstaller-5.13.2-py3-none-win32.whl", hash = "sha256:421cd24f26144f19b66d3868b49ed673176765f92fa9f7914cd2158d25b6d17e"},
+    {file = "pyinstaller-5.13.2-py3-none-win_amd64.whl", hash = "sha256:ddcc2b36052a70052479a9e5da1af067b4496f43686ca3cdda99f8367d0627e4"},
+    {file = "pyinstaller-5.13.2-py3-none-win_arm64.whl", hash = "sha256:27cd64e7cc6b74c5b1066cbf47d75f940b71356166031deb9778a2579bb874c6"},
+    {file = "pyinstaller-5.13.2.tar.gz", hash = "sha256:c8e5d3489c3a7cc5f8401c2d1f48a70e588f9967e391c3b06ddac1f685f8d5d2"},
 ]
 
 [package.dependencies]
@@ -661,13 +661,13 @@ hook-testing = ["execnet (>=1.5.0)", "psutil", "pytest (>=2.7.3)"]
 
 [[package]]
 name = "pyinstaller-hooks-contrib"
-version = "2023.7"
+version = "2023.8"
 description = "Community maintained hooks for PyInstaller"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "pyinstaller-hooks-contrib-2023.7.tar.gz", hash = "sha256:0c436a4c3506020e34116a8a7ddfd854c1ad6ddca9a8cd84500bd6e69c9e68f9"},
-    {file = "pyinstaller_hooks_contrib-2023.7-py2.py3-none-any.whl", hash = "sha256:3c10df14c0f71ab388dfbf1625375b087e7330d9444cbfd2b310ba027fa0cff0"},
+    {file = "pyinstaller-hooks-contrib-2023.8.tar.gz", hash = "sha256:318ccc316fb2b8c0bbdff2456b444bf1ce0e94cb3948a0f4dd48f6fc33d41c01"},
+    {file = "pyinstaller_hooks_contrib-2023.8-py2.py3-none-any.whl", hash = "sha256:d091a52fbeed71cde0359aa9ad66288521a8441cfba163d9446606c5136c72a8"},
 ]
 
 [[package]]
@@ -738,13 +738,13 @@ cli = ["click (>=5.0)"]
 
 [[package]]
 name = "pytz"
-version = "2023.3"
+version = "2023.3.post1"
 description = "World timezone definitions, modern and historical"
 optional = false
 python-versions = "*"
 files = [
-    {file = "pytz-2023.3-py2.py3-none-any.whl", hash = "sha256:a151b3abb88eda1d4e34a9814df37de2a80e301e68ba0fd856fb9b46bfbbbffb"},
-    {file = "pytz-2023.3.tar.gz", hash = "sha256:1d8ce29db189191fb55338ee6d0387d82ab59f3d00eac103412d64e0ebd0c588"},
+    {file = "pytz-2023.3.post1-py2.py3-none-any.whl", hash = "sha256:ce42d816b81b68506614c11e8937d3aa9e41007ceb50bfdcb0749b921bf646c7"},
+    {file = "pytz-2023.3.post1.tar.gz", hash = "sha256:7b4fddbeb94a1eba4b557da24f19fdf9db575192544270a9101d8509f9f43d7b"},
 ]
 
 [[package]]
@@ -830,19 +830,19 @@ test = ["asv", "gmpy2", "mpmath", "pooch", "pytest", "pytest-cov", "pytest-timeo
 
 [[package]]
 name = "setuptools"
-version = "68.1.2"
+version = "68.2.1"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "setuptools-68.1.2-py3-none-any.whl", hash = "sha256:3d8083eed2d13afc9426f227b24fd1659489ec107c0e86cec2ffdde5c92e790b"},
-    {file = "setuptools-68.1.2.tar.gz", hash = "sha256:3d4dfa6d95f1b101d695a6160a7626e15583af71a5f52176efa5d39a054d475d"},
+    {file = "setuptools-68.2.1-py3-none-any.whl", hash = "sha256:eff96148eb336377ab11beee0c73ed84f1709a40c0b870298b0d058828761bae"},
+    {file = "setuptools-68.2.1.tar.gz", hash = "sha256:56ee14884fd8d0cd015411f4a13f40b4356775a0aefd9ebc1d3bfb9a1acb32f1"},
 ]
 
 [package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5,<=7.1.2)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
 testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
-testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.1)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
 name = "six"
@@ -1121,5 +1121,5 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.8,<=3.11.4"
-content-hash = "5112cef9c1a00bcdbf8a1f917702c9ed47b81aba4decf850557ea3e52d63c8b8"
+python-versions = ">=3.8,<=3.11"
+content-hash = "278ba28b0fc3596c5ecb615d171ecd8342e1e745ca3a5b06dc1afc58e9fa97e7"

--- a/pypet2bids/pypet2bids/dcm2niix4pet.py
+++ b/pypet2bids/pypet2bids/dcm2niix4pet.py
@@ -34,7 +34,6 @@ import importlib
 import dotenv
 import logging
 
-
 try:
     import helper_functions
     import is_pet
@@ -43,7 +42,6 @@ except ModuleNotFoundError:
     import pypet2bids.is_pet as is_pet
 
 logger = logging.getLogger("pypet2bids")
-
 
 # fields to check for
 module_folder = Path(__file__).parent.resolve()
@@ -382,7 +380,7 @@ class Dcm2niix4PET:
                 logger.warning(f"Minimum version {minimum_version} of dcm2niix is recommended, found "
                                f"installed version {version[0]} at {self.dcm2niix_path}.")
 
-        #check if user provided a custom tempdir location
+        # check if user provided a custom tempdir location
         self.tempdir_location = tempdir_location
         self.image_folder = Path(image_folder)
         if destination_path:
@@ -474,7 +472,8 @@ class Dcm2niix4PET:
                             **self.additional_arguments))
 
             # check for any blood (tsv) data or otherwise in the given spreadsheet values
-            blood_tsv_columns = ['time', 'plasma_radioactivity', 'metabolite_parent_fraction', 'whole_blood_radioactivity']
+            blood_tsv_columns = ['time', 'plasma_radioactivity', 'metabolite_parent_fraction',
+                                 'whole_blood_radioactivity']
             blood_json_columns = ['PlasmaAvail', 'WholeBloodAvail', 'MetaboliteAvail', 'MetaboliteMethod',
                                   'MetaboliteRecoveryCorrectionApplied', 'DispersionCorrected']
 
@@ -667,7 +666,7 @@ class Dcm2niix4PET:
 
                     sidecar_json = JsonMAJ(json_path=str(created),
                                            bids_null=True,
-                                           update_values=self.additional_arguments) # load all supplied and now written sidecar data in
+                                           update_values=self.additional_arguments)  # load all supplied and now written sidecar data in
 
                     sidecar_json.update()
 
@@ -969,8 +968,8 @@ def check_meta_radio_inputs(kwargs: dict) -> dict:
             tmp = (InjectedRadioactivity * 10 ** 6) / (InjectedMass * 10 ** 6)
             if SpecificRadioactivity:
                 if SpecificRadioactivity != tmp:
-                    print(colored("WARNING inferred SpecificRadioactivity in Bq/g doesn't match InjectedRadioactivity "
-                                  "and InjectedMass, could be a unit issue", "yellow"))
+                    logger.warning("Inferred SpecificRadioactivity in Bq/g doesn't match InjectedRadioactivity "
+                                   "and InjectedMass, could be a unit issue", "yellow")
                 data_out['SpecificRadioactivity'] = SpecificRadioactivity
                 data_out['SpecificRadioactivityUnits'] = kwargs.get('SpecificRadioactivityUnityUnits', 'n/a')
             else:
@@ -991,8 +990,8 @@ def check_meta_radio_inputs(kwargs: dict) -> dict:
             tmp = ((InjectedRadioactivity * (10 ** 6) / SpecificRadioactivity) * (10 ** 6))
             if InjectedMass:
                 if InjectedMass != tmp:
-                    print(colored("WARNING Infered InjectedMass in ug doesn't match InjectedRadioactivity and "
-                                  "InjectedMass, could be a unit issue", "yellow"))
+                    logger.warning("Inferred InjectedMass in ug doesn't match InjectedRadioactivity and "
+                                   "InjectedMass, could be a unit issue", "yellow")
                 data_out['InjectedMass'] = InjectedMass
                 data_out['InjectedMassUnits'] = kwargs.get('InjectedMassUnits', 'n/a')
             else:
@@ -1014,8 +1013,8 @@ def check_meta_radio_inputs(kwargs: dict) -> dict:
                     10 ** 6)  # ((ug / 10 ^ 6) / Bq / g)/10 ^ 6 = MBq
             if InjectedRadioactivity:
                 if InjectedRadioactivity != tmp:
-                    print(colored("WARNING inferred InjectedRadioactivity in MBq doesn't match SpecificRadioactivity "
-                                  "and InjectedMass, could be a unit issue", "yellow"))
+                    logger.warning("Inferred InjectedRadioactivity in MBq doesn't match SpecificRadioactivity "
+                                   "and InjectedMass, could be a unit issue", "yellow")
                 data_out['InjectedRadioactivity'] = InjectedRadioactivity
                 data_out['InjectedRadioactivityUnits'] = kwargs.get('InjectedRadioactivityUnits', 'n/a')
             else:
@@ -1036,8 +1035,9 @@ def check_meta_radio_inputs(kwargs: dict) -> dict:
             tmp = (MolarActivity * (10 ** 3)) / MolecularWeight  # (GBq / umol * 10 ^ 6) / (g / mol / * 10 ^ 6) = Bq / g
             if SpecificRadioactivity:
                 if SpecificRadioactivity != tmp:
-                    print(colored("inferred SpecificRadioactivity in MBq/ug doesn't match Molar Activity and Molecular "
-                                  "Weight, could be a unit issue", 'yellow'))
+                    logger.warning(
+                        "Inferred SpecificRadioactivity in MBq/ug doesn't match Molar Activity and Molecular "
+                        "Weight, could be a unit issue", 'yellow')
                 data_out['SpecificRadioactivity'] = SpecificRadioactivity
                 data_out['SpecificRadioactivityUnits'] = kwargs.get('SpecificRadioactivityUnityUnits', 'n/a')
             else:
@@ -1058,8 +1058,8 @@ def check_meta_radio_inputs(kwargs: dict) -> dict:
             tmp = (MolarActivity * 1000) / SpecificRadioactivity  # (MBq / ug / 1000) / (GBq / umol) = g / mol
             if MolecularWeight:
                 if MolecularWeight != tmp:
-                    print(colored("WARNING Inferred MolecularWeight in MBq/ug doesn't match Molar Activity and "
-                                  "Molecular Weight, could be a unit issue", 'yellow'))
+                    logger.warning("Inferred MolecularWeight in MBq/ug doesn't match Molar Activity and "
+                                   "Molecular Weight, could be a unit issue", 'yellow')
 
                 data_out['MolecularWeight'] = tmp
                 data_out['MolecularWeightUnits'] = kwargs.get('MolecularWeightUnits', 'n/a')
@@ -1081,8 +1081,8 @@ def check_meta_radio_inputs(kwargs: dict) -> dict:
             tmp = MolecularWeight * (SpecificRadioactivity / 1000)  # g / mol * (MBq / ug / 1000) = GBq / umol
             if MolarActivity:
                 if MolarActivity != tmp:
-                    print(colored("WARNING inferred MolarActivity in GBq/umol doesn't match Specific Radioactivity and "
-                                  "Molecular Weight, could be a unit issue", "yellow"))
+                    logger.warning("Inferred MolarActivity in GBq/umol doesn't match Specific Radioactivity and "
+                                   "Molecular Weight, could be a unit issue", "yellow")
                 data_out['MolarActivity'] = MolarActivity
                 data_out['MolarActivityUnits'] = kwargs.get('MolarActivityUnits', 'n/a')
             else:
@@ -1179,7 +1179,8 @@ def cli():
                              "omitted defaults to using the path supplied to folder path. If destination path " +
                              "doesn't exist an attempt to create it will be made.", required=False)
     parser.add_argument('--tempdir', type=str, default=None,
-                        help="User-specified tempdir location (overrides default system tempfile default)", required=False)
+                        help="User-specified tempdir location (overrides default system tempfile default)",
+                        required=False)
     parser.add_argument('--kwargs', '-k', nargs='*', action=helper_functions.ParseKwargs, default={},
                         help="Include additional values in the nifti sidecar json or override values extracted from "
                              "the supplied nifti. e.g. including `--kwargs TimeZero=\"12:12:12\"` would override the "

--- a/pypet2bids/pyproject.toml
+++ b/pypet2bids/pyproject.toml
@@ -1,18 +1,12 @@
 [tool.poetry]
 name = "pypet2bids"
-version = "1.2.4"
+version = "1.2.5"
 description = "A python implementation of an ECAT to BIDS converter."
 authors = ["anthony galassi <28850131+bendhouseart@users.noreply.github.com>"]
 license = "MIT"
 include = [
-    'pypet2bids/metadata/blood_metadata.json',
-    'pypet2bids/metadata/definitions.json',
-    'pypet2bids/metadata/dicom2bids.json',
-    'pypet2bids/metadata/PET_metadata.json',
-    'pypet2bids/metadata/PET_Radionuclide.mkd',
-    'pypet2bids/metadata/PET_reconstruction_methods.json',
+    'pypet2bids/metadata/*',
     'pypet2bids/pyproject.toml',
-    'pypet2bids/metadata/README',
     ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
Pandas seems to consider booleans to be 1 and 0, this update uses the schema to check for 1 and 0 and if that entity should be a boolean converts it to  a python `True` or `False` which when written out as a json should persist as a bool type there.