### PR TITLE
Update get_recon_method.m

### DIFF
--- a/matlab/get_recon_method.m
+++ b/matlab/get_recon_method.m
@@ -21,7 +21,7 @@ subset    = [];
 
 %% load metadata from the library
 current    = which('ecat2nii.m');
-pn_parts   = strsplit(fileparts(current), '/');
+pn_parts   = strsplit(fileparts(current), filesep);
 jsontoload = fullfile(strjoin(pn_parts(1:end-1), '/'), 'metadata', 'PET_reconstruction_methods.json');
 if exist(jsontoload,'file')
     reconstruction_metadata = jsondecode(fileread(jsontoload));

--- a/matlab/get_recon_method.m
+++ b/matlab/get_recon_method.m
@@ -21,8 +21,8 @@ subset    = [];
 
 %% load metadata from the library
 current    = which('ecat2nii.m');
-root       = current(1:strfind(current,'matlab')-1);
-jsontoload = fullfile(root,['metadata' filesep 'PET_reconstruction_methods.json']);
+pn_parts   = strsplit(fileparts(current), '/');
+jsontoload = fullfile(strjoin(pn_parts(1:end-1), '/'), 'metadata', 'PET_reconstruction_methods.json');
 if exist(jsontoload,'file')
     reconstruction_metadata = jsondecode(fileread(jsontoload));
     reconstruction_metadata = reconstruction_metadata.reconstruction_names;


### PR DESCRIPTION
PET_reconstruction_methods.json location defined relative to ecat2nii.m location, no longer with respect to "matlab" folder level, which is problematic if "matlab" occurs twice in ecat2nii.m path (e.g., /usr/matlab/PET2BIDS/matlab/ecat2nii.m)