### PR TITLE
Convert msec to sec for ECAT to BIDS json

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -3,6 +3,7 @@
 The following individuals have contributed to the PET2BIDS project (in alphabetical order). If you contributed and
 some icons needs to be added or your name is not listed, please add it.
 
+Murat Bilgel 💻 🐛 💡
 Anthony Galassi 💻 📖 💬 🎨 💡 ⚠️  
 Melanie Ganz-Benjaminsen 🔍 💬 🤔 📋  
 Gabriel Gonzalez-Escamilla 💻 ⚠️ 🐛 👀  

--- a/pypet2bids/pypet2bids/read_ecat.py
+++ b/pypet2bids/pypet2bids/read_ecat.py
@@ -144,6 +144,9 @@ def get_header_data(header_data_map: dict, ecat_file: str = '', byte_offset: int
         header[variable_name] = struct.unpack(struct_fmt, raw_bytes)
         if clean and 'fill' not in variable_name.lower():
             header[variable_name] = filter_bytes(header[variable_name], struct_fmt)
+        if 'comment' in value and 'msec' in value['comment']:
+            # for entries that are in msec, convert to sec for PET BIDS json
+            header[variable_name] /= 1000
         read_head_position = relative_byte_position + byte_width
 
     return header, read_head_position


### PR DESCRIPTION
Various ECAT entries are in msec, including several frame time entries. These need to be converted to seconds to be compatible with PET-BIDS. The python implementation currently doesn't check the time unit, resulting in msec values in the json.

This PR determines which ECAT entries are in msec by looking at the "comment" field in `ecat_headers.json` and converts their values to seconds.

Verified that the conversion works for the ECAT v7.0 example included in the repo and for ECAT v7.3. Will add this ECAT v7.3 phantom data to the Google folder.