### PR TITLE
Tested previously failing phantoms, pass now.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,7 @@ buildpackage:
 	@cd pypet2bids && poetry lock && poetry build
 
 publish:
-	@cd pypet2bids
-	@poetry publish
+	@cd pypet2bids && poetry publish
 
 installpoetry:
 	@cd scripts && ./installpoetry

--- a/scripts/python_conversions.sh
+++ b/scripts/python_conversions.sh
@@ -135,54 +135,52 @@ ReconMethodParameterValues="[0, 0]"
 # PhilipsGeminiPETMR
 # --------------------------------------
 
-# Note this creates a dcm2niix error, it's a known Philips bug; leaving for the sake of completness
+echo "${SOURCE_FOLDER}/PhilipsGeminiPETMR-Unimedizin/reqCTAC"
+dcm2niix4pet $SOURCE_FOLDER/PhilipsGeminiPETMR-Unimedizin/reqCTAC --destination-path $DESTINATION/sub-PhilipsGeminiUnimedizinMainz/pet \
+--kwargs \
+Manufacturer="Philips Medical Systems" \
+ManufacturersModelName="PET/CT Gemini TF16"
+InstitutionName="Unimedizin, Mainz, DE" \
+BodyPart="Phantom" \
+Units="Bq/mL" \
+TracerName="Fallypride" \
+TracerRadionuclide="F18" \
+InjectedRadioactivity=114 \
+SpecificRadioactivity=800 \
+ModeOfAdministration="infusion" \
+AcquisitionMode="list mode" \
+ImageDecayCorrected=True \
+ImageDecayCorrectionTime=0 \
+ReconFilterType='n/a' \
+ReconFilterSize=0 \
+AttenuationCorrection="CTAC-SG" \
+ScatterCorrectionMethod="SS-SIMUL" \
+ReconstructionMethod="LOR-RAMLA" \
+ReconMethodParameterValues="[1,1]"
+ FrameDuration=[1798] \
 
-#echo "${SOURCE_FOLDER}/PhilipsGeminiPETMR-Unimedizin/reqCTAC"
-#dcm2niix4pet $SOURCE_FOLDER/PhilipsGeminiPETMR-Unimedizin/reqCTAC --destination-path $DESTINATION/sub-PhilipsGeminiUnimedizinMainz/pet \
-#--kwargs \
-#Manufacturer="Philips Medical Systems" \
-#ManufacturersModelName="PET/CT Gemini TF16"
-#InstitutionName="Unimedizin, Mainz, DE" \
-#BodyPart="Phantom" \
-#Units="Bq/mL" \
-#TracerName="Fallypride" \
-#TracerRadionuclide="F18" \
-#InjectedRadioactivity=114 \
-#SpecificRadioactivity=800 \
-#ModeOfAdministration="infusion" \
-#AcquisitionMode="list mode" \
-#ImageDecayCorrected=True \
-#ImageDecayCorrectionTime=0 \
-#ReconFilterType='n/a' \
-#ReconFilterSize=0 \
-#AttenuationCorrection="CTAC-SG" \
-#ScatterCorrectionMethod="SS-SIMUL" \
-#ReconstructionMethod="LOR-RAMLA" \
-#ReconMethodParameterValues="[1,1]"
-# FrameDuration=[1798] \
-
-#echo "${SOURCE_FOLDER}/PhilipsGeminiPETMR-Unimedizin/reqNAC"
-#dcm2niix4pet $SOURCE_FOLDER/PhilipsGeminiPETMR-Unimedizin/reqNAC --destination-path $DESTINATION/sub-PhilipsGeminiNACUnimedizinMainz/pet \
-#--kwargs \
-#Manufacturer="Philips Medical Systems" \
-#ManufacturersModelName="PET/CT Gemini TF16"
-#InstitutionName="Unimedizin, Mainz, DE" \
-#BodyPart="Phantom" \
-#Units="Bq/mL" \
-#TracerName="Fallypride" \
-#TracerRadionuclide="F18" \
-#InjectedRadioactivity=114 \
-#SpecificRadioactivity=800 \
-#ModeOfAdministration="infusion" \
-#AcquisitionMode="list mode" \
-#ImageDecayCorrected=True \
-#ImageDecayCorrectionTime=0 \
-#ReconFilterType=None \
-#ReconFilterSize=0 \
-#AttenuationCorrection="None" \
-#ScatterCorrectionMethod="None" \
-#ReconstructionMethod="3D-RAMLA"
-## FrameDuration=[1798] \
+echo "${SOURCE_FOLDER}/PhilipsGeminiPETMR-Unimedizin/reqNAC"
+dcm2niix4pet $SOURCE_FOLDER/PhilipsGeminiPETMR-Unimedizin/reqNAC --destination-path $DESTINATION/sub-PhilipsGeminiNACUnimedizinMainz/pet \
+--kwargs \
+Manufacturer="Philips Medical Systems" \
+ManufacturersModelName="PET/CT Gemini TF16"
+InstitutionName="Unimedizin, Mainz, DE" \
+BodyPart="Phantom" \
+Units="Bq/mL" \
+TracerName="Fallypride" \
+TracerRadionuclide="F18" \
+InjectedRadioactivity=114 \
+SpecificRadioactivity=800 \
+ModeOfAdministration="infusion" \
+AcquisitionMode="list mode" \
+ImageDecayCorrected=True \
+ImageDecayCorrectionTime=0 \
+ReconFilterType=None \
+ReconFilterSize=0 \
+AttenuationCorrection="None" \
+ScatterCorrectionMethod="None" \
+ReconstructionMethod="3D-RAMLA"
+FrameDuration=[1798] \
 
 # Amsterdam UMC
 # ---------------------------

--- a/scripts/python_conversions.sh
+++ b/scripts/python_conversions.sh
@@ -139,7 +139,7 @@ echo "${SOURCE_FOLDER}/PhilipsGeminiPETMR-Unimedizin/reqCTAC"
 dcm2niix4pet $SOURCE_FOLDER/PhilipsGeminiPETMR-Unimedizin/reqCTAC --destination-path $DESTINATION/sub-PhilipsGeminiUnimedizinMainz/pet \
 --kwargs \
 Manufacturer="Philips Medical Systems" \
-ManufacturersModelName="PET/CT Gemini TF16"
+ManufacturersModelName="PET/CT Gemini TF16" \
 InstitutionName="Unimedizin, Mainz, DE" \
 BodyPart="Phantom" \
 Units="Bq/mL" \
@@ -156,14 +156,17 @@ ReconFilterSize=0 \
 AttenuationCorrection="CTAC-SG" \
 ScatterCorrectionMethod="SS-SIMUL" \
 ReconstructionMethod="LOR-RAMLA" \
-ReconMethodParameterValues="[1,1]"
- FrameDuration=[1798] \
+ReconMethodParameterValues="[1,1]" \
+FrameDuration=[1798] \
+ReconMethodParameterLabels="[none, none]" \
+ReconMethodParameterUnits="[none, none]" \
+FrameTimesStart=[0] \
 
 echo "${SOURCE_FOLDER}/PhilipsGeminiPETMR-Unimedizin/reqNAC"
 dcm2niix4pet $SOURCE_FOLDER/PhilipsGeminiPETMR-Unimedizin/reqNAC --destination-path $DESTINATION/sub-PhilipsGeminiNACUnimedizinMainz/pet \
 --kwargs \
 Manufacturer="Philips Medical Systems" \
-ManufacturersModelName="PET/CT Gemini TF16"
+ManufacturersModelName="PET/CT Gemini TF16" \
 InstitutionName="Unimedizin, Mainz, DE" \
 BodyPart="Phantom" \
 Units="Bq/mL" \
@@ -179,8 +182,13 @@ ReconFilterType=None \
 ReconFilterSize=0 \
 AttenuationCorrection="None" \
 ScatterCorrectionMethod="None" \
-ReconstructionMethod="3D-RAMLA"
+ReconstructionMethod="3D-RAMLA" \
 FrameDuration=[1798] \
+ReconMethodParameterLabels="[none, none]" \
+ReconMethodParameterUnits="[none, none]" \
+ReconMethodParameterValues="[1,1]" \
+FrameTimesStart=[0] \
+
 
 # Amsterdam UMC
 # ---------------------------


### PR DESCRIPTION
Version v1.0.20220720 of dcm2niix fixed some issues with Phillips dicoms. Uncommented those previously failing phantoms in python_conversions.sh and ran `make phantoms` they convert and pass the validator.