### PR TITLE
Bug fix: enable json sidecar generation for older dcm2niix versions

### DIFF
--- a/pypet2bids/pypet2bids/dcm2niix4pet.py
+++ b/pypet2bids/pypet2bids/dcm2niix4pet.py
@@ -612,7 +612,7 @@ class Dcm2niix4PET:
             tempdir_pathlike = Path(tempdir)
             # people use screwy paths, we do this before running dcm2niix to account for that
             image_folder = helper_functions.sanitize_bad_path(self.image_folder)
-            cmd = f"{self.dcm2niix_path} -w 1 -z y {file_format_args} -o {tempdir_pathlike} {image_folder}"
+            cmd = f"{self.dcm2niix_path} -b y -w 1 -z y {file_format_args} -o {tempdir_pathlike} {image_folder}"
             convert = subprocess.run(cmd, shell=True, capture_output=True)
 
             if convert.returncode != 0:

--- a/pypet2bids/pyproject.toml
+++ b/pypet2bids/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pypet2bids"
-version = "1.2.9"
+version = "1.2.10"
 description = "A python implementation of an ECAT to BIDS converter."
 authors = ["anthony galassi <28850131+bendhouseart@users.noreply.github.com>"]
 license = "MIT"


### PR DESCRIPTION
Issue: No json output after running `dcm2niix4pet`.

Reason: Older versions of `dcm2niix` don't generate the json sidecar by default.

Fix: Added `-b y` argument to `dcm2niix` to enable the generation of the json sidecar for older versions. This change should not affect the behavior with the latest version of `dcm2niix`.