### PR TITLE
Shape using number of subheaders rather than number frames from main …

### DIFF
--- a/pypet2bids/pypet2bids/ecat2nii.py
+++ b/pypet2bids/pypet2bids/ecat2nii.py
@@ -90,7 +90,7 @@ def ecat2nii(ecat_main_header=None,
     shape_from_headers = (sub_headers[0]['X_DIMENSION'],
                           sub_headers[0]['Y_DIMENSION'],
                           sub_headers[0]['Z_DIMENSION'],
-                          main_header['NUM_FRAMES'])
+                          len(sub_headers))
 
     # make sure number of data elements matches frame number
     single_frame = False
@@ -105,7 +105,7 @@ def ecat2nii(ecat_main_header=None,
     img_temp = numpy.zeros(shape=(sub_headers[0]['X_DIMENSION'],
                                   sub_headers[0]['Y_DIMENSION'],
                                   sub_headers[0]['Z_DIMENSION'],
-                                  main_header['NUM_FRAMES']),
+                                  len(sub_headers),
                            dtype=numpy.dtype('>f4'))
 
     # collect timing information


### PR DESCRIPTION
…header

Using the number of frames from the main header causes issues when that number differs from the real number of frames enumerated in the subheaders and in the image data. Instead using the number of subheaders (or alternatively, making an option to use the number of subheaders or a subset of frames) instead ensures the data sizes are in agreement.

<!-- readthedocs-preview pet2bids start -->
----
📚 Documentation preview 📚: https://pet2bids--265.org.readthedocs.build/en/265/

<!-- readthedocs-preview pet2bids end -->