### PR TITLE
[Ecat2Nii] Only apply ECAT_CALIBRATION_FACTOR if it has not already b…

### DIFF
--- a/pypet2bids/pypet2bids/ecat2nii.py
+++ b/pypet2bids/pypet2bids/ecat2nii.py
@@ -133,9 +133,9 @@ def ecat2nii(ecat_main_header=None,
             randoms.append(0)
 
     ecat_cal_units = main_header['CALIBRATION_UNITS']  # Header field designating whether data has already been calibrated
-    if ecat_cal_units==0:                              # Calibrate if it hasn't been already
+    if ecat_cal_units==1:                              # Calibrate if it hasn't been already
         final_image = img_temp * main_header['ECAT_CALIBRATION_FACTOR']
-    elif ecat_cal_units==1:                            # And don't calibrate if it has
+    else:                            # And don't calibrate if CALIBRATION_UNITS is anything else but 1
         final_image = img_temp
 
     qoffset_x = -1 * (

--- a/pypet2bids/pypet2bids/ecat2nii.py
+++ b/pypet2bids/pypet2bids/ecat2nii.py
@@ -132,7 +132,11 @@ def ecat2nii(ecat_main_header=None,
             prompts.append(0)
             randoms.append(0)
 
-    final_image = img_temp * main_header['ECAT_CALIBRATION_FACTOR']
+    ecat_cal_units = main_header['CALIBRATION_UNITS']  # Header field designating whether data has already been calibrated
+    if ecat_cal_units==0:                              # Calibrate if it hasn't been already
+        final_image = img_temp * main_header['ECAT_CALIBRATION_FACTOR']
+    elif ecat_cal_units==1:                            # And don't calibrate if it has
+        final_image = img_temp
 
     qoffset_x = -1 * (
         ((sub_headers[0]['X_DIMENSION'] * sub_headers[0]['X_PIXEL_SIZE'] * 10 / 2) - sub_headers[0][

--- a/pypet2bids/pypet2bids/ecat2nii.py
+++ b/pypet2bids/pypet2bids/ecat2nii.py
@@ -191,7 +191,7 @@ def ecat2nii(ecat_main_header=None,
 
     # TODO img_nii.header['scl_slope'] # this is a NaN array by default but apparently it should be the dose calibration
     #  factor img_nii.header['scl_inter'] # defaults to NaN array
-    img_nii.header['scl_slope'] = main_header['ECAT_CALIBRATION_FACTOR']
+    img_nii.header['scl_slope'] = 0
     img_nii.header['scl_inter'] = 0
     img_nii.header['slice_end'] = 0
     img_nii.header['slice_code'] = 0

--- a/pypet2bids/pyproject.toml
+++ b/pypet2bids/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pypet2bids"
-version = "1.3.1"
+version = "1.3.5"
 description = "A python implementation of an ECAT to BIDS converter."
 authors = ["anthony galassi <28850131+bendhouseart@users.noreply.github.com>"]
 license = "MIT"

--- a/pypet2bids/pyproject.toml
+++ b/pypet2bids/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pypet2bids"
-version = "1.3.5"
+version = "1.3.4"
 description = "A python implementation of an ECAT to BIDS converter."
 authors = ["anthony galassi <28850131+bendhouseart@users.noreply.github.com>"]
 license = "MIT"


### PR DESCRIPTION
…een applied; check CALIBRATION_UNITS to see if calibration has been applied, if it has, return input image, otherwise multiply by calibration factor.

This change will correctly account for whether the calibration factor has already been applied to Ecat data. In the current version of PET2BIDS, ecat2nii will erroneously reapply the calibration factor on data that has already been calibrated, resulting in Nifti files with incorrect data objects.

<!-- readthedocs-preview pet2bids start -->
----
📚 Documentation preview 📚: https://pet2bids--268.org.readthedocs.build/en/268/

<!-- readthedocs-preview pet2bids end -->