### PR TITLE
Fix uneven blood spreadsheets

### DIFF
--- a/pypet2bids/pypet2bids/dcm2niix4pet.py
+++ b/pypet2bids/pypet2bids/dcm2niix4pet.py
@@ -206,7 +206,7 @@ class Dcm2niix4PET:
         # replace the suffix in the destination path with '' if a non-nifti full file path is give
         if Path(destination_path).suffix:
             self.full_file_path_given = True
-            self.destination_folder = destination_path.parent
+            self.destination_folder = Path(destination_path).parent
             self.destination_path = Path(destination_path).with_suffix('')
 
         if not self.full_file_path_given:

--- a/pypet2bids/pypet2bids/update_json_pet_file.py
+++ b/pypet2bids/pypet2bids/update_json_pet_file.py
@@ -618,6 +618,15 @@ def get_metadata_from_spreadsheet(metadata_path: Union[str, Path], image_folder,
         except KeyError:
             pass
 
+    # even out the values in the blood tsv columns if they're different lengths by appending zeros to the end
+    # of each column/list
+    # determine the longest column
+    longest_column = max([len(column) for column in spreadsheet_metadata['blood_tsv'].values()])
+    # iterate over each column, determine how many zeros to append to the end of each column
+    for column in spreadsheet_metadata['blood_tsv'].keys():
+        zeros_to_append = longest_column - len(spreadsheet_metadata['blood_tsv'][column])
+        spreadsheet_metadata['blood_tsv'][column] += [0] * zeros_to_append
+
     # check for existing blood json values
     for column in blood_json_columns:
         try:

--- a/pypet2bids/pyproject.toml
+++ b/pypet2bids/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pypet2bids"
-version = "1.3.4"
+version = "1.3.5"
 description = "A python implementation of an ECAT to BIDS converter."
 authors = ["anthony galassi <28850131+bendhouseart@users.noreply.github.com>"]
 license = "MIT"


### PR DESCRIPTION
fixes issue where extra/missing blood values read in from a spreadsheet would cause conversion to error out due to array/list/dataseries length mismatch. Determines the length of the longest blood column and appends zeros to all other columns that are too short.

<!-- readthedocs-preview pet2bids start -->
----
📚 Documentation preview 📚: https://pet2bids--273.org.readthedocs.build/en/273/

<!-- readthedocs-preview pet2bids end -->