### PR TITLE
no longer tries to write rescaling factor to .txt file

### DIFF
--- a/matlab/ecat2nii.m
+++ b/matlab/ecat2nii.m
@@ -211,12 +211,12 @@ for j=1:length(FileListIn)
                 Sca      = Sca*MinImg/(-32768);
             end
 
-            % save scaling factor to file located at ecat_save_steps_dir/8.5_sca_matlab.txt
-            fid = fopen([ecat_save_steps_dir filesep '8.5_sca_matlab.txt'],'w');
-            fprintf(fid,'Scaling factor: %10e\n',Sca);
-            x = mh.ecat_calibration_factor * Sca;
-            fprintf(fid,'Scaling factor * ECAT Cal Factor: %10.10f\n',x);
-            fclose(fid);
+            % % save scaling factor to file located at ecat_save_steps_dir/8.5_sca_matlab.txt
+            % fid = fopen([ecat_save_steps_dir filesep '8.5_sca_matlab.txt'],'w');
+            % fprintf(fid,'Scaling factor: %10e\n',Sca);
+            % x = mh.ecat_calibration_factor * Sca;
+            % fprintf(fid,'Scaling factor * ECAT Cal Factor: %10.10f\n',x);
+            % fclose(fid);
         end
 
         % save debugging step 8 - rescale to 16 bits


### PR DESCRIPTION
Commented lines that write rescaling info to .txt file in .../PET2BIDS/ecat_testing/steps

<!-- readthedocs-preview pet2bids start -->
----
📚 Documentation preview 📚: https://pet2bids--331.org.readthedocs.build/en/331/

<!-- readthedocs-preview pet2bids end -->