### PR TITLE
Fix bug in make_nifti method to handle Path objects correctly

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -12,6 +12,7 @@ Granville Matheson 📝 🐛 ✅
 Martin Norgaard 💻 💬 🤔 ⚠️ 👀  
 Cyril Pernet 💻 📖 💬 🎨 💡 📋 🤔 ⚠️  
 Chris Rorden 💻 🐛 📖  
+Maximilian Cosmo Sitter 💻
 Claus Svarer 💻 💡⚠️   
 Adam G Thomas  🔍 🤔  
 Robert Innis 💡⚠️💵   

--- a/pypet2bids/pypet2bids/ecat.py
+++ b/pypet2bids/pypet2bids/ecat.py
@@ -244,7 +244,7 @@ class Ecat:
         self.telemetry_data["NiftiFiles"] = 1
         self.telemetry_data["NiftiFilesSize"] = pathlib.Path(output).stat().st_size
 
-        if "nii.gz" not in output:
+        if "nii.gz" not in pathlib.Path(output).name:
             output = helper_functions.compress(output)
 
         return output


### PR DESCRIPTION
This pull request includes a bug fix in the `pypet2bids/ecat.py` file and I added myself to the `contributors.md` file.

I modified the `make_nifti` method to correctly check if the output file name ends with "nii.gz" using `pathlib.Path(output).name` instead of checking the entire path string. Since `pathlib.Path` objects are not iterable, the `"nii.gz" not in output` check would otherwise throw a TypeError, if `output` is not a string but a `Path` object. Since providing the nifti_file as a pathlib.Path object does not throw errors in other places of the code, at least when running `.convert()`, I considered this a bug.

<!-- readthedocs-preview pet2bids start -->
----
📚 Documentation preview 📚: https://pet2bids--333.org.readthedocs.build/en/333/

<!-- readthedocs-preview pet2bids end -->