### PR TITLE
fix val error when extracting recon size

### DIFF
--- a/pypet2bids/pypet2bids/dcm2niix4pet.py
+++ b/pypet2bids/pypet2bids/dcm2niix4pet.py
@@ -480,7 +480,7 @@ class Dcm2niix4PET:
             self.tempdir_location = tempdir_pathlike
             # people use screwy paths, we do this before running dcm2niix to account for that
             image_folder = helper_functions.sanitize_bad_path(self.image_folder)
-            cmd = f"{self.dcm2niix_path} -b y -w 1 -z y {file_format_args} -o {tempdir_pathlike} {image_folder}"
+            cmd = f"{self.dcm2niix_path} -b y -m Y -w 1 -z y -s y {file_format_args} -o {tempdir_pathlike} {image_folder}"
             convert = subprocess.run(cmd, shell=True, capture_output=True)
             self.telemetry_data["dcm2niix"] = {
                 "returncode": convert.returncode,


### PR DESCRIPTION
Hi @bendhouseart 
Hope all is well

When using e7tools by Siemens, the ReconFilterSize field == 'GAUSSIAN 3 3', for example. 

This produces the following error:

```ValueError: could not convert string to float: '3 3'```

I've added a try/except statement to handle this specific case. I am assuming that any institute running e7tools would run into this problem!

Rami

<!-- readthedocs-preview pet2bids start -->
----
📚 Documentation preview 📚: https://pet2bids--353.org.readthedocs.build/en/353/

<!-- readthedocs-preview pet2bids end -->