### PR TITLE
apply changes requested from PR #353

### DIFF
--- a/.blackignore
+++ b/.blackignore
@@ -1,0 +1,111 @@
+# Virtual environments
+.venv/
+venv/
+env/
+ENV/
+env.bak/
+venv.bak/
+
+# Python cache
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+.pytest_cache/
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Project specific
+__MACOSX/
+*.zip
+*.mat
+*.v
+*.v.gz
+*.avi
+*.jpg
+*.bytes 

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,4 @@ pythongithubworkflow: installdependencies collectphantoms decompressphantoms tes
 	@echo finished running python tests
 
 black:
-	@for file in `find pypet2bids/ -name "*.py"`; do \
-		black $$file; \
-	done
+	@black pypet2bids/

--- a/pypet2bids/pyproject.toml
+++ b/pypet2bids/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pypet2bids"
-version = "1.4.3"
+version = "1.4.4"
 description = "A python library for converting PET imaging and blood data to BIDS."
 authors = [
     {name = "anthony galassi", email = "28850131+bendhouseart@users.noreply.github.com"}

--- a/pypet2bids/pyproject.toml
+++ b/pypet2bids/pyproject.toml
@@ -52,6 +52,7 @@ dev = [
     "pyinstaller>=5.4.1",
     "build>=0.10.0",
     "briefcase>=0.3.23; python_version>='3.9'",
+    "black>=23.0.0",
 ]
 
 [project.scripts]
@@ -78,3 +79,21 @@ include = [
     "/pypet2bids",
     "/README.md",
 ]
+
+[tool.black]
+line-length = 88
+target-version = ['py38']
+include = '\.pyi?$'
+extend-exclude = '''
+/(
+  # directories
+  \.eggs
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | build
+  | dist
+)/
+'''


### PR DESCRIPTION
Adds dcm2niix options so user can get up to all kinds of nonsense if required.

All dcm2niix options (barring `-f`) can be modified with:

- the `--dcm2niix-options` flag
- adding them to `~/.pet2bidsconfig` via `PET2BIDS_DCM2NIIX_OPTIONS=`
- or simply exporting them via the same environmental variable `PET2BIDS_DCM2NIIX_OPTIONS` 

<!-- readthedocs-preview pet2bids start -->
----
📚 Documentation preview 📚: https://pet2bids--357.org.readthedocs.build/en/357/

<!-- readthedocs-preview pet2bids end -->