### PR TITLE
Fix ECAT .convert() to pass kwargs and support TimeZero

### DIFF
--- a/pypet2bids/pypet2bids/ecat.py
+++ b/pypet2bids/pypet2bids/ecat.py
@@ -241,7 +241,7 @@ class Ecat:
             ecat_pixel_data=self.data,
             nifti_file=output,
             affine=self.affine,
-            kwargs=self.kwargs,
+            **self.kwargs,
         )
 
         self.telemetry_data["NiftiFiles"] = 1

--- a/pypet2bids/pypet2bids/ecat.py
+++ b/pypet2bids/pypet2bids/ecat.py
@@ -241,6 +241,7 @@ class Ecat:
             ecat_pixel_data=self.data,
             nifti_file=output,
             affine=self.affine,
+            kwargs=self.kwargs,
         )
 
         self.telemetry_data["NiftiFiles"] = 1


### PR DESCRIPTION
Previously, .convert() didn’t pass kwargs to ecat2nii, so parameters like TimeZero couldn’t be applied and triggered warnings. This update ensures kwargs are forwarded properly, allowing TimeZero to be set and reducing unnecessary warnings.

<!-- readthedocs-preview pet2bids start -->
----
📚 Documentation preview 📚: https://pet2bids--376.org.readthedocs.build/en/376/

<!-- readthedocs-preview pet2bids end -->