### PR TITLE
Fix scaling calculations for image data to match the Python version to the MATLAB version

### DIFF
--- a/pypet2bids/pypet2bids/ecat2nii.py
+++ b/pypet2bids/pypet2bids/ecat2nii.py
@@ -228,12 +228,12 @@ def ecat2nii(
     rg = img_temp.max() - img_temp.min()
     if rg != 32767:
         max_img = img_temp.max()
-        img_temp = img_temp / max_img * 32767
+        img_temp = (img_temp / max_img) * 32767
         sca = max_img / 32767
         min_img = img_temp.min()
         if min_img < -32768:
-            img_temp = img_temp / (min_img * -32768)
-            sca = sca * (min_img * -32768)
+            img_temp = (img_temp / min_img) * (-32768)
+            sca = (sca * min_img) / (-32768)
     if ecat_save_steps == "1":
         with open(os.path.join(steps_dir, "8.5_sca.txt"), "w") as sca_file:
             sca_file.write(f"Scaling factor: {sca}\n")


### PR DESCRIPTION
Fixes #371 

When initially adapting image scaling from the MATLAB version to Python, the scaling calculations were inconsistent. This PR aims to resolve this issue, and adds brackets to reduce potential ambiguity with order of operations.

<!-- readthedocs-preview pet2bids start -->
----
📚 Documentation preview 📚: https://pet2bids--377.org.readthedocs.build/en/377/

<!-- readthedocs-preview pet2bids end -->