### PR TITLE
Add ruff format configuration and replace black

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,5 +86,5 @@ testotherpython:
 pythongithubworkflow: installdependencies collectphantoms decompressphantoms testecatread testecatcli testotherpython
 	@echo finished running python tests
 
-black:
-	@black pypet2bids/
+format:
+	@uv run ruff format pypet2bids/

--- a/pypet2bids/pypet2bids/convert_pmod_to_blood.py
+++ b/pypet2bids/pypet2bids/convert_pmod_to_blood.py
@@ -243,7 +243,6 @@ class PmodToBlood:
         engine="",
         **kwargs,
     ):
-
         if kwargs:
             try:
                 self.kwargs = kwargs["kwargs"]
@@ -280,7 +279,9 @@ class PmodToBlood:
                 "sub", self.output_path
             )
         else:
-            helper_functions.logger("pypet2bids").warning("Subject id not found in output_path, checking key pair input.")
+            helper_functions.logger("pypet2bids").warning(
+                "Subject id not found in output_path, checking key pair input."
+            )
             self.subject_id = self.kwargs.get("subject_id", "")
 
         if helper_functions.collect_bids_part("ses", str(self.output_path)):
@@ -288,7 +289,9 @@ class PmodToBlood:
                 "ses", self.output_path
             )
         else:
-            helper_functions.logger("pypet2bids").warning("Session id not found in output_path, checking key pair input.")
+            helper_functions.logger("pypet2bids").warning(
+                "Session id not found in output_path, checking key pair input."
+            )
             self.session_id = self.kwargs.get("session_id", "")
 
         self.output_json = output_json
@@ -296,9 +299,7 @@ class PmodToBlood:
         self.auto_sampled = []
         self.manually_sampled = []
         self.blood_series = {}
-        self.duplicates = (
-            {}
-        )  # list of times that are duplicated across manual and automatic samples
+        self.duplicates = {}  # list of times that are duplicated across manual and automatic samples
 
         if whole_blood_activity.is_file():
             self.blood_series["whole_blood_activity"] = self.load_pmod_file(
@@ -580,7 +581,6 @@ class PmodToBlood:
                         != self.blood_series[new_string]["time"][0]
                         and parent_fraction["time"][0] == 0
                     ):
-
                         self.blood_series[new_string].loc[-1] = [0, 0]
                         self.blood_series[new_string].index = (
                             self.blood_series[new_string].index + 1
@@ -610,7 +610,6 @@ class PmodToBlood:
                 ).shape[0]
                 != 0
             ):
-
                 wba = self.blood_series["whole_blood_activity_manually_popped"]
                 new_plasma = (
                     wba["whole_blood_radioactivity"]

--- a/pypet2bids/pypet2bids/dcm2niix4pet.py
+++ b/pypet2bids/pypet2bids/dcm2niix4pet.py
@@ -599,7 +599,9 @@ class Dcm2niix4PET:
                     bytes("Skipping existing file name", "utf-8") not in convert.stdout
                     or convert.stderr
                 ):
-                    helper_functions.logger("pypet2bids").warning(convert.stderr.decode("utf-8"))
+                    helper_functions.logger("pypet2bids").warning(
+                        convert.stderr.decode("utf-8")
+                    )
                 elif (
                     convert.returncode != 0
                     and bytes("Error: Check sorted order", "utf-8") in convert.stdout
@@ -970,7 +972,7 @@ class Dcm2niix4PET:
             if type(blood_tsv_data) is pd.DataFrame or type(blood_tsv_data) is dict:
                 if type(blood_tsv_data) is dict:
                     blood_tsv_data = pd.DataFrame(blood_tsv_data)
-                
+
                 # remove any empty rows
                 blood_tsv_data = helper_functions.remove_zero_rows(blood_tsv_data)
 
@@ -1130,8 +1132,10 @@ class Dcm2niix4PET:
                 spec.loader.exec_module(module)
                 text_file_data = module.translate_metadata(self.metadata_dataframe)
             except AttributeError as err:
-               helper_functions.logger("pypet2bids").error(f"Unable to locate metadata_translation_script")
-               raise err
+                helper_functions.logger("pypet2bids").error(
+                    f"Unable to locate metadata_translation_script"
+                )
+                raise err
 
             self.spreadsheet_metadata["blood_tsv"] = text_file_data.get("blood_tsv", {})
             self.spreadsheet_metadata["blood_json"] = text_file_data.get(

--- a/pypet2bids/pypet2bids/ecat.py
+++ b/pypet2bids/pypet2bids/ecat.py
@@ -87,12 +87,8 @@ class Ecat:
         self.subheaders = []  # subheader information is placed here
         self.ecat_info = {}
         self.affine = {}  # affine matrix/information is stored here.
-        self.frame_start_times = (
-            []
-        )  # frame_start_times, frame_durations, and decay_factors are all
-        self.frame_durations = (
-            []
-        )  # extracted from ecat subheaders. They're pretty important and get
+        self.frame_start_times = []  # frame_start_times, frame_durations, and decay_factors are all
+        self.frame_durations = []  # extracted from ecat subheaders. They're pretty important and get
         self.decay_factors = []  # stored here
         self.sidecar_template = (
             sidecar.sidecar_template_full
@@ -131,7 +127,7 @@ class Ecat:
             raise FileNotFoundError(ecat_file)
 
         if helper_functions.get_zip_extension(self.ecat_file) and decompress is True:
-            uncompressed_ecat_file = self.ecat_file.with_suffix('')
+            uncompressed_ecat_file = self.ecat_file.with_suffix("")
             helper_functions.decompress(self.ecat_file, uncompressed_ecat_file)
             self.ecat_file = uncompressed_ecat_file
 
@@ -142,7 +138,9 @@ class Ecat:
         try:
             self.ecat = nibabel.ecat.load(self.ecat_file)
         except nibabel.filebasedimages.ImageFileError as err:
-            helper_functions.logger("pypet2bids").error("\nFailed to load ecat image.\n")
+            helper_functions.logger("pypet2bids").error(
+                "\nFailed to load ecat image.\n"
+            )
             raise err
 
         directory_byte_block = read_ecat.read_bytes(
@@ -232,16 +230,18 @@ class Ecat:
         :rtype: pathlib.Path
         """
         final_target = (
-            pathlib.Path(output_path).expand_user() if output_path is not None else self.nifti_file
+            pathlib.Path(output_path).expand_user()
+            if output_path is not None
+            else self.nifti_file
         )
         gz = helper_functions.get_zip_extension(final_target)
         if gz:
             write_path = final_target.parent / final_target.name[: -len(gz)]
-        elif not gz and '.nii' not in final_target.suffix.lower():
-            write_path = final_target.with_suffix('.nii')
+        elif not gz and ".nii" not in final_target.suffix.lower():
+            write_path = final_target.with_suffix(".nii")
         else:
             write_path = final_target
-        
+
         write_path.parent.mkdir(parents=True, exist_ok=True)
 
         ecat2nii.ecat2nii(

--- a/pypet2bids/pypet2bids/ecat2nii.py
+++ b/pypet2bids/pypet2bids/ecat2nii.py
@@ -77,8 +77,7 @@ def ecat2nii(
         and type(ecat_pixel_data) is numpy.ndarray
     )
     any_in_memory = any(
-        x is not None
-        for x in (ecat_main_header, ecat_subheaders, ecat_pixel_data)
+        x is not None for x in (ecat_main_header, ecat_subheaders, ecat_pixel_data)
     )
 
     if full_in_memory:
@@ -278,24 +277,18 @@ def ecat2nii(
         final_image = numpy.round(final_image) * sca
 
     qoffset_x = -1 * (
-        (
-            (sub_headers[0]["X_DIMENSION"] * sub_headers[0]["X_PIXEL_SIZE"] * 10 / 2)
-            - sub_headers[0]["X_PIXEL_SIZE"] * 5
-        )
+        (sub_headers[0]["X_DIMENSION"] * sub_headers[0]["X_PIXEL_SIZE"] * 10 / 2)
+        - sub_headers[0]["X_PIXEL_SIZE"] * 5
     )
 
     qoffset_y = -1 * (
-        (
-            (sub_headers[0]["Y_DIMENSION"] * sub_headers[0]["Y_PIXEL_SIZE"] * 10 / 2)
-            - sub_headers[0]["Y_PIXEL_SIZE"] * 5
-        )
+        (sub_headers[0]["Y_DIMENSION"] * sub_headers[0]["Y_PIXEL_SIZE"] * 10 / 2)
+        - sub_headers[0]["Y_PIXEL_SIZE"] * 5
     )
 
     qoffset_z = -1 * (
-        (
-            (sub_headers[0]["Z_DIMENSION"] * sub_headers[0]["Z_PIXEL_SIZE"] * 10 / 2)
-            - sub_headers[0]["Z_PIXEL_SIZE"] * 5
-        )
+        (sub_headers[0]["Z_DIMENSION"] * sub_headers[0]["Z_PIXEL_SIZE"] * 10 / 2)
+        - sub_headers[0]["Z_PIXEL_SIZE"] * 5
     )
 
     # build affine if it's not included in function call

--- a/pypet2bids/pypet2bids/ecat_cli.py
+++ b/pypet2bids/pypet2bids/ecat_cli.py
@@ -126,7 +126,7 @@ def cli():
     parser.add_argument(
         "--sidecar",
         action="store_true",
-        help="Output a bids formatted sidecar for pairing with" "a nifti.",
+        help="Output a bids formatted sidecar for pairing witha nifti.",
     )
     parser.add_argument(
         "--kwargs",

--- a/pypet2bids/pypet2bids/ecat_cli.py
+++ b/pypet2bids/pypet2bids/ecat_cli.py
@@ -126,7 +126,7 @@ def cli():
     parser.add_argument(
         "--sidecar",
         action="store_true",
-        help="Output a bids formatted sidecar for pairing witha nifti.",
+        help="Output a bids formatted sidecar for pairing with a nifti.",
     )
     parser.add_argument(
         "--kwargs",

--- a/pypet2bids/pypet2bids/helper_functions.py
+++ b/pypet2bids/pypet2bids/helper_functions.py
@@ -132,7 +132,6 @@ def single_spreadsheet_reader(
     dicom_metadata={},
     **kwargs,
 ) -> dict:
-
     spreadsheet_metadata = {}
     metadata_fields = pet2bids_metadata
 
@@ -197,11 +196,10 @@ def single_spreadsheet_reader(
 
 
 def compress(
-        file_like_object: Union[str, pathlib.Path], 
-        output_path: Union[str, pathlib.Path] = None,
-        delete_original=True,
-    ) -> pathlib.Path:
-    
+    file_like_object: Union[str, pathlib.Path],
+    output_path: Union[str, pathlib.Path] = None,
+    delete_original=True,
+) -> pathlib.Path:
     delete_original = delete_original
     """
     Compresses a file using gzip in place, set delete_original = False to keep uncompressed image.
@@ -239,7 +237,7 @@ def compress(
 
 
 def decompress(
-    file_like_object: Union[str, pathlib.Path], 
+    file_like_object: Union[str, pathlib.Path],
     output_path: Union[str, pathlib.Path] = None,
 ) -> pathlib.Path:
     """
@@ -253,7 +251,7 @@ def decompress(
     file_like_object = pathlib.Path(file_like_object).expanduser().resolve()
     if not output_path and get_zip_extension(file_like_object):
         output_path = file_like_object.with_suffix("")
-    
+
     compressed_file = gzip.GzipFile(str(file_like_object))
     compressed_input = compressed_file.read()
     compressed_file.close()
@@ -1175,29 +1173,31 @@ def reorder_isotope(isotope: str) -> str:
 
     return isotope
 
+
 def remove_zero_rows(sheet: pandas.DataFrame) -> pandas.DataFrame:
     zero_rows = sheet.eq(0.0).all(axis=1)
     if True in zero_rows.values:
         fixed_tsv = sheet[~zero_rows]
         sheet = fixed_tsv
-    return sheet    
+    return sheet
+
 
 def suffixes_lower(path: pathlib.Path) -> tuple:
     return tuple(s.lower() for s in path.suffixes)
 
 
-def get_zip_extension(path: pathlib.Path) -> (str or None):
+def get_zip_extension(path: pathlib.Path) -> str or None:
     """
     Determines if a the provided filepath has a gz extension, if
     so returns that extension as written.
 
-    :param path: path to check for gzip 
+    :param path: path to check for gzip
     :type path: pathlib.Path
     :return: gzip extension if present
     :rtype: str
     """
-    gz = re.search(r'\.[gG][zZ]$', str(path))
+    gz = re.search(r"\.[gG][zZ]$", str(path))
     if gz:
         return gz.group(0)
     else:
-        return ''
+        return ""

--- a/pypet2bids/pypet2bids/read_ecat.py
+++ b/pypet2bids/pypet2bids/read_ecat.py
@@ -26,6 +26,7 @@ from pypet2bids import helper_functions
 import numpy
 from pypet2bids.helper_functions import decompress, first_middle_last_frames_to_text
 from pypet2bids.helper_functions import logger
+
 parent_dir = pathlib.Path(__file__).parent.resolve()
 code_dir = parent_dir.parent
 data_dir = code_dir.parent
@@ -480,7 +481,6 @@ def read_ecat(
             pixel_data_matrix_4d[:, :, :, index] = frame
 
         if ecat_save_steps == "1":
-
             # write out the endianness and datatype of the pixel data matrix
             step_3_dict = {
                 "datatype": pixel_data_matrix_4d.dtype.name,

--- a/pypet2bids/pypet2bids/update_json_pet_file.py
+++ b/pypet2bids/pypet2bids/update_json_pet_file.py
@@ -15,15 +15,17 @@ from pandas import Timestamp
 
 try:
     import helper_functions
-    # The import of is_pet is deferred to get_metadata_from_spreadsheet() to 
+
+    # The import of is_pet is deferred to get_metadata_from_spreadsheet() to
     # prevent circular import
-    #import is_pet
+    # import is_pet
     import pet_metadata as metadata
 except ModuleNotFoundError:
     import pypet2bids.helper_functions as helper_functions
-    # The import of is_pet is deferred to get_metadata_from_spreadsheet() to 
+
+    # The import of is_pet is deferred to get_metadata_from_spreadsheet() to
     # prevent circular import
-    #import pypet2bids.is_pet as is_pet
+    # import pypet2bids.is_pet as is_pet
     import pypet2bids.pet_metadata as metadata
 
 # import logging

--- a/pypet2bids/pypet2bids/write_ecat.py
+++ b/pypet2bids/pypet2bids/write_ecat.py
@@ -3,21 +3,21 @@ This program will create an ecat file if provided an ecat schema and a dictionar
 with.
 
 First this program collects the same schemas that read_ecat.py does, from read_ecat import ecat_header_maps.
-Next this program selects one of the header maps as specified by some input e.g. if given: ecat7.3 it would 
-select the standard image matrix at: ecat_header_maps['ecat_headers']['73']['mainheader'] 
-and the subheader map at: ecat_header_maps['ecat_headers']['73']['11'] or whatever number is corresponding to 
+Next this program selects one of the header maps as specified by some input e.g. if given: ecat7.3 it would
+select the standard image matrix at: ecat_header_maps['ecat_headers']['73']['mainheader']
+and the subheader map at: ecat_header_maps['ecat_headers']['73']['11'] or whatever number is corresponding to
 the type of ecat header you wish to write. Perhaps these should belong in a reverse sort of dictionary going to
-need to create the directory byte block(s) for an ecat. Basically, reverse the process of reading the 
-directory in lines 227 through 257 in ecat_read. 
-    
+need to create the directory byte block(s) for an ecat. Basically, reverse the process of reading the
+directory in lines 227 through 257 in ecat_read.
+
     determine the number of frames in the image/pixel data
-    create empty table(s) of dtype >i4 dimensions of 4 rows by 64 columns 
+    create empty table(s) of dtype >i4 dimensions of 4 rows by 64 columns
     fill empty tables w/ zeros
-    place the number 2 in the second row, first column of the table if it's the only directory table or the last 
+    place the number 2 in the second row, first column of the table if it's the only directory table or the last
     directory
     table.
     final output should be a bytes: 1024 type object.
-    
+
 After generating the table you should then be able to write the main header, write the directory table,
 then write each subheader and corresponding pixel data
 
@@ -33,6 +33,7 @@ from pypet2bids.read_ecat import ecat_header_maps, get_buffer_size
 import numpy
 from pathlib import Path
 from pypet2bids.helper_functions import logger
+
 
 def write_header(
     ecat_file,
@@ -250,10 +251,8 @@ def write_ecat(
     pixel_byte_size: int,
     pixel_data: list = [],
 ):
-
     # open the ecat file!
     with open(ecat_file, "w+b") as outfile:
-
         # first things first, write the main header with supplied information
         write_header(
             ecat_file=outfile, schema=mainheader_schema, values=mainheader_values

--- a/pypet2bids/pyproject.toml
+++ b/pypet2bids/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pypet2bids"
-version = "1.5.0"
+version = "1.5.1"
 description = "A python library for converting PET imaging and blood data to BIDS."
 authors = [
     {name = "anthony galassi", email = "28850131+bendhouseart@users.noreply.github.com"}

--- a/pypet2bids/pyproject.toml
+++ b/pypet2bids/pyproject.toml
@@ -99,3 +99,16 @@ extend-exclude = '''
   | dist
 )/
 '''
+
+[tool.ruff]
+line-length = 88
+extend-exclude = [
+  ".eggs",
+  ".git",
+  ".hg",
+  ".mypy_cache",
+  ".tox",
+  ".venv",
+  "build",
+  "dist",
+]

--- a/pypet2bids/pyproject.toml
+++ b/pypet2bids/pyproject.toml
@@ -53,7 +53,7 @@ dev = [
     "pyinstaller>=5.4.1",
     "build>=0.10.0",
     "briefcase>=0.3.23; python_version>='3.9'",
-    "black>=23.0.0",
+    "ruff>=0.15.0",
 ]
 
 [project.scripts]

--- a/pypet2bids/pyproject.toml
+++ b/pypet2bids/pyproject.toml
@@ -82,24 +82,6 @@ include = [
     "/pypet2bids/dcm2niix_binaries/*.zip"
 ]
 
-[tool.black]
-line-length = 88
-target-version = ['py38']
-include = '\.pyi?$'
-extend-exclude = '''
-/(
-  # directories
-  \.eggs
-  | \.git
-  | \.hg
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | build
-  | dist
-)/
-'''
-
 [tool.ruff]
 line-length = 88
 extend-exclude = [

--- a/pypet2bids/tests/metadata_excel_example_reader.py
+++ b/pypet2bids/tests/metadata_excel_example_reader.py
@@ -22,7 +22,6 @@ def flatten_series(series):
 
 
 def translate_metadata(metadata_dataframe, image_path=NotImplemented):
-
     nifti_json = {
         "Manufacturer": "",
         "ManufacturersModelName": "",

--- a/pypet2bids/tests/test_convert_pmod_to_blood.py
+++ b/pypet2bids/tests/test_convert_pmod_to_blood.py
@@ -142,7 +142,7 @@ class TestPmodToBlood:
                     Ex_bld_whole_blood_only_files["plasma"][0]
                 ),
                 output_path=pathlib.Path(tempdir),
-                **kwargs_input
+                **kwargs_input,
             )
 
     def test_load_bld_files_mixed(self, Ex_bld_manual_and_autosampled_mixed):
@@ -164,7 +164,7 @@ class TestPmodToBlood:
                     Ex_bld_manual_and_autosampled_mixed["parent"][0]
                 ),
                 output_path=tempdir,
-                **kwargs_input
+                **kwargs_input,
             )
 
     def test_bld_output_manual_popped_values(self, Ex_bld_manual_and_autosampled_mixed):
@@ -187,7 +187,7 @@ class TestPmodToBlood:
                     Ex_bld_manual_and_autosampled_mixed["parent"][0]
                 ),
                 output_path=tempdir,
-                **kwargs_input
+                **kwargs_input,
             )
 
             created_files = [
@@ -234,7 +234,7 @@ class TestPmodToBlood:
                     Ex_txt_manual_and_autosampled_mixed["parent"][0]
                 ),
                 output_path=tempdir,
-                **kwargs_input
+                **kwargs_input,
             )
 
     def test_txt_output_manual_popped_values(self, Ex_txt_manual_and_autosampled_mixed):
@@ -256,7 +256,7 @@ class TestPmodToBlood:
                     Ex_txt_manual_and_autosampled_mixed["parent"][0]
                 ),
                 output_path=tempdir,
-                **kwargs_input
+                **kwargs_input,
             )
 
             created_files = [

--- a/pypet2bids/tests/test_helper_functions.py
+++ b/pypet2bids/tests/test_helper_functions.py
@@ -416,7 +416,7 @@ def test_remove_zero_rows():
         {
             "time": [0.0, 10.0, 0.0, 20.0],
             "plasma_radioactivity": [0.0, 5.5, 0.0, 6.2],
-            "whole_blood_radioactivity": [0.0, 4.2, 3.0, 5.0,],
+            "whole_blood_radioactivity": [0.0, 4.2, 3.0, 5.0],
         }
     )
     result_mixed = helper_functions.remove_zero_rows(data_mixed)

--- a/pypet2bids/tests/test_included_binaries.py
+++ b/pypet2bids/tests/test_included_binaries.py
@@ -80,9 +80,9 @@ class TestIncludedBinaries:
                 assert config_path.exists(), "Config file was not created"
 
                 saved_path = helper_functions.check_pet2bids_config("DCM2NIIX_PATH")
-                assert str(saved_path) == str(
-                    binary_path
-                ), f"Config path does not match extracted path: {saved_path} != {binary_path}"
+                assert str(saved_path) == str(binary_path), (
+                    f"Config path does not match extracted path: {saved_path} != {binary_path}"
+                )
         finally:
             # Restore original config if it existed
             if config_backup is not None:
@@ -153,15 +153,15 @@ class TestIncludedBinaries:
                 import re
 
                 version_match = re.search(r"v[0-9]+\.[0-9]+\.\d{8}", version_output)
-                assert (
-                    version_match is not None
-                ), f"Could not parse version from: {version_output}"
+                assert version_match is not None, (
+                    f"Could not parse version from: {version_output}"
+                )
 
                 version = version_match.group(0)
                 minimum_version = "v1.0.20220720"
-                assert (
-                    version >= minimum_version
-                ), f"Version {version} is below minimum {minimum_version}"
+                assert version >= minimum_version, (
+                    f"Version {version} is below minimum {minimum_version}"
+                )
 
     def test_binary_path_consistency(self):
         """Test that the same binary path is returned on multiple calls."""

--- a/pypet2bids/tests/test_library_command_line_interfaces.py
+++ b/pypet2bids/tests/test_library_command_line_interfaces.py
@@ -81,13 +81,12 @@ def test_for_show_examples_argument():
         check_for_show_examples = subprocess.run(
             f"{installed} --show-examples", shell=True, capture_output=True
         )
-        assert (
-            check_for_show_examples.returncode == 0
-        ), f"{installed} does not have a --show-examples option"
+        assert check_for_show_examples.returncode == 0, (
+            f"{installed} does not have a --show-examples option"
+        )
 
 
 def test_kwargs_produce_valid_conversion(tmp_path):
-
     # prepare a set of kwargs (stolen from a valid bids subject/dataset, mum's the word ;) )
     full_set_of_kwargs = {
         "Modality": "PT",
@@ -278,7 +277,6 @@ def test_spreadsheets_produce_valid_conversion_ecatpet2bids(tmp_path):
 
 
 def test_scanner_params_produce_valid_conversion(tmp_path):
-
     # test scanner params txt with ecat conversion
     ecatpet2bids_scanner_params_test_dir = tmp_path / "ecat_scanner_params_test"
     ecatpet2bids_scanner_params_test_dir.mkdir(parents=True, exist_ok=True)

--- a/pypet2bids/tests/test_thisbytes.py
+++ b/pypet2bids/tests/test_thisbytes.py
@@ -25,7 +25,6 @@ if __name__ == "__main__":
     check_header_json = True
 
     if check_header_json:
-
         for header, header_values in ecat_header_maps["ecat_headers"].items():
             for header_name, header_map in header_values.items():
                 byte_position = 0
@@ -60,7 +59,6 @@ if __name__ == "__main__":
     """
     check_byte_reading = False
     if check_byte_reading:
-
         load_dotenv(env_path)
         ecat_test_file = os.environ.get("TEST_ECAT_PATH")
 

--- a/pypet2bids/tests/test_write_ecat.py
+++ b/pypet2bids/tests/test_write_ecat.py
@@ -50,7 +50,6 @@ class TestECATWrite(unittest.TestCase):
         }
 
     def test_create_directory_table(self):
-
         generated_directory_table = create_directory_table(
             self.known_main_header["NUM_FRAMES"],
             self.pixel_dimensions,


### PR DESCRIPTION
Hi,

this PR introduces Ruff for code formatting by adding its configuration and removing Black, and applies formatting changes throughout the codebase. I also added a new Makefile target format, and in a follow-up PR I’ll introduce a lint target as well.

Since there’s currently no CI or pre-commit setup in place, we should probably add a GitHub Action that runs Ruff in CI to check the codebase and report issues, with auto-fixing enabled where possible so formatting changes can be applied automatically when needed.

In general, there are two common approaches here: either rely on pre-commit hooks to enforce standards locally before commits are made, or keep things simpler and enforce everything in CI with automated fixes applied there. I’d prefer the simpler CI-only approach for now, without pre-commit hooks, so CI becomes the single source of truth while still keeping contributions easy.

First PR to tackle #387

<!-- readthedocs-preview pet2bids start -->
----
📚 Documentation preview 📚: https://pet2bids--389.org.readthedocs.build/en/389/

<!-- readthedocs-preview pet2bids end -->