### PR TITLE
fix: use the NumPy product reduction API

### DIFF
--- a/pypet2bids/pypet2bids/write_ecat.py
+++ b/pypet2bids/pypet2bids/write_ecat.py
@@ -130,7 +130,7 @@ def create_directory_table(
     required_directory_blocks = ceil(num_frames / 31)
 
     # determine the width of the frame byte blocks with the pixel dimensions and data sizes
-    pixel_volume = numpy.product([*pixel_dimensions.values()])
+    pixel_volume = numpy.prod([*pixel_dimensions.values()])
 
     # still not sure what some of these numbers mean, but we populate the first column of the byte array with them
     directory_tables = []


### PR DESCRIPTION
`numpy.prod` is the canonical product reduction. NumPy 2 removed the `numpy.product` alias.

This change replaces `numpy.product` with `numpy.prod` in 1 file.


<!-- readthedocs-preview pet2bids start -->
----
📚 Documentation preview 📚: https://pet2bids--395.org.readthedocs.build/en/395/

<!-- readthedocs-preview pet2bids end -->