### PR TITLE
Calculate RecordingStart

### DIFF
--- a/matlab/ecat2nii.m
+++ b/matlab/ecat2nii.m
@@ -339,6 +339,11 @@ for j=1:length(FileListIn)
             info.InjectionStart               = 0;
         end
 
+        % time difference between ScanStart and start time of first reconstructed volume
+        if isfield(info, 'RecordingStart')
+            info.RecordingStart = info.ScanStart + sh{1}.frame_start_time*60; % convert minutes to seconds
+        end 
+
         info.DoseCalibrationFactor            = Sca*mh.ecat_calibration_factor;
         info.Filemoddate                      = datestr(now);
         info.Version                          = 'NIfTI1';


### PR DESCRIPTION
Introduce RecordingStart field.

HRRT PET scanners (perhaps other scanners) can be set such that start time of first reconstructed volume is when number of counts exceeds a threshold value. This means ScanStart will not necessarily reflect the start time of first reconstructed volume, i.e., there is a time delay between ScanStart and start time of first reconstructed volume. This time delay is indexed by RecordingStart, reported in seconds.

Note: this time delay may also mean FrameTimesStart should be adjusted.

<!-- readthedocs-preview pet2bids start -->
----
📚 Documentation preview 📚: https://pet2bids--397.org.readthedocs.build/en/397/

<!-- readthedocs-preview pet2bids end -->